### PR TITLE
Add utility method to get voting status for kicked validators

### DIFF
--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -111,6 +111,15 @@ contract Staking is ReentrancyGuard, Pausable, Ownable {
         return validators[account].balance;
     }
 
+    function getVotingStatusToKickValidator(
+        uint256 epochNumber,
+        address validatorStakerAddress,
+        address voterStakerAddress
+    ) external view returns (uint256, bool) {
+        VoteToKickValidatorInNextEpoch storage votingStatus = votesToKickValidatorsInNextEpoch[epochNumber][validatorStakerAddress];
+        return (votingStatus.votes, votingStatus.voted[voterStakerAddress]);
+    }
+
     function getValidatorsInCurrentEpoch()
         external
         view

--- a/test/Staking.js
+++ b/test/Staking.js
@@ -602,6 +602,9 @@ describe("Staking", function () {
       );
       const totalStakedBefore = await stakingContract.totalStaked();
 
+      // get epoch number
+      const epoch = await stakingContract.epoch();
+
       // vote to kick the last stakingAccount
       for (let i = 0; i < stakingAccounts.length - 1; i++) {
         const stakingAccount = stakingAccounts[i];
@@ -610,6 +613,15 @@ describe("Staking", function () {
         await stakingContract.kickValidatorInNextEpoch(
           toBeKicked.stakingAddress.getAddress()
         );
+
+        // assert votesToKickValidatorsInNextEpoch state
+        const [numVotes, didStakerVote] = await stakingContract.getVotingStatusToKickValidator(
+          epoch.number,
+          toBeKicked.stakingAddress.getAddress(),
+          stakingAccount.stakingAddress.getAddress(),
+        );
+        expect(numVotes).equal(i+1);
+        expect(didStakerVote).is.true;
       }
 
       const validatorsInNextEpochAfter =


### PR DESCRIPTION
# What

- Title.
- Unit tests for the new getter method.

As I am implementing integration tests that result in nodes voting to kick peers, I need to have an easy way to query the state of the votes against a particular validator.

# Testing

`yarn test`