### PR TITLE
Disable signer updates for AccessControlConditions

### DIFF
--- a/contracts/AccessControlConditions.sol
+++ b/contracts/AccessControlConditions.sol
@@ -88,6 +88,10 @@ contract AccessControlConditions is
                 storedConditions[key].permanent == false,
                 "This condition was stored with the Permanent flag and cannot be updated"
             );
+            require(
+                msg.sender != signer,
+                "Signer cannot update conditions"
+            );
         }
         storedConditions[key] = StoredCondition(
             value,

--- a/test/AccessControlConditions.js
+++ b/test/AccessControlConditions.js
@@ -286,7 +286,7 @@ describe("AccessControlConditions", function () {
         );
       });
       
-      it("retrieves condition and updates it", async () => {
+      it("retrieves condition and fails to update it with incorrect creator", async () => {
         let [
           valueFromContract,
           securityHashFromContract,
@@ -316,16 +316,7 @@ describe("AccessControlConditions", function () {
           )
         ).revertedWith("Only the condition creator can update it");
 
-        // update with the correct address
-        await contract.connect(trustedSigner).storeConditionWithSigner(
-          key,
-          newValue,
-          newSecurityHash,
-          newChainId,
-          permanent,
-          creator.address,
-        );
-
+        // verify that nothing changed
         [
           valueFromContract,
           securityHashFromContract,
@@ -333,12 +324,57 @@ describe("AccessControlConditions", function () {
           permanentFromContract,
           creatorFromContract,
         ] = await contract.getCondition(key);
-        expect(valueFromContract).equal(newValue);
-        expect(securityHashFromContract).equal(newSecurityHash);
-        expect(chainIdFromContract).equal(newChainId);
+        expect(valueFromContract).equal(value);
+        expect(securityHashFromContract).equal(securityHash);
+        expect(chainIdFromContract).equal(chainId);
         expect(permanentFromContract).equal(permanent);
         expect(creatorFromContract).equal(creator.address);
       });
+      
+      it("retrieves condition and fails to update it with correct creator", async () => {
+        let [
+          valueFromContract,
+          securityHashFromContract,
+          chainIdFromContract,
+          permanentFromContract,
+          creatorFromContract,
+        ] = await contract.getCondition(key);
+        expect(valueFromContract).equal(value);
+        expect(securityHashFromContract).equal(securityHash);
+        expect(chainIdFromContract).equal(chainId);
+        expect(permanentFromContract).equal(permanent);
+        expect(creatorFromContract).equal(creator.address);
+
+        const newSecurityHash = 0x1337;
+        const newValue = 0x8765;
+        const newChainId = 2;
+
+        // attempt to update it with the wrong address.  it should revert.
+        expect(
+          contract.connect(trustedSigner).storeConditionWithSigner(
+            key,
+            newValue,
+            newSecurityHash,
+            newChainId,
+            permanent,
+            creator.address,
+          )
+        ).revertedWith("Signer cannot update conditions");
+
+        // verify that nothing changed
+        [
+          valueFromContract,
+          securityHashFromContract,
+          chainIdFromContract,
+          permanentFromContract,
+          creatorFromContract,
+        ] = await contract.getCondition(key);
+        expect(valueFromContract).equal(value);
+        expect(securityHashFromContract).equal(securityHash);
+        expect(chainIdFromContract).equal(chainId);
+        expect(permanentFromContract).equal(permanent);
+        expect(creatorFromContract).equal(creator.address);
+      })
     });
 
     context("when key is correct and condition is permanent", async () => {
@@ -368,7 +404,7 @@ describe("AccessControlConditions", function () {
         );
       });
 
-      it("retrieves condition and attempts to update it", async () => {
+      it("retrieves condition and fails to update it", async () => {
         let [
           valueFromContract,
           securityHashFromContract,


### PR DESCRIPTION
# What

Disable updates to stored conditions from the trusted signer for security reasons. That way, even if the signer private key is leaked, it doesn't put all non-permanent stored conditions in the contract at risk.

No ABI updates needed.

# Testing

`yarn run test`

