### PR TITLE
feat: enable prettier

### DIFF
--- a/contracts/AccessControlConditions.sol
+++ b/contracts/AccessControlConditions.sol
@@ -9,16 +9,16 @@ import "hardhat/console.sol";
 contract AccessControlConditions is Ownable, ReentrancyGuard {
     /* ========== STRUCTS ========== */
     struct StoredCondition {
-        uint value;
-        uint securityHash;
-        uint chainId;
+        uint256 value;
+        uint256 securityHash;
+        uint256 chainId;
         bool permanent;
         address creator;
     }
 
     /* ========== STATE VARIABLES ========== */
 
-    mapping(uint => StoredCondition) public storedConditions;
+    mapping(uint256 => StoredCondition) public storedConditions;
     address public signer;
 
     /* ========== CONSTRUCTOR ========== */
@@ -28,19 +28,21 @@ contract AccessControlConditions is Ownable, ReentrancyGuard {
 
     /* ========== VIEWS ========== */
 
-    function getCondition(
-        uint key
-    ) external view returns (StoredCondition memory) {
+    function getCondition(uint256 key)
+        external
+        view
+        returns (StoredCondition memory)
+    {
         return storedConditions[key];
     }
 
     /* ========== MUTATIVE FUNCTIONS ========== */
 
     function storeCondition(
-        uint key,
-        uint value,
-        uint securityHash,
-        uint chainId,
+        uint256 key,
+        uint256 value,
+        uint256 securityHash,
+        uint256 chainId,
         bool permanent
     ) external nonReentrant {
         _storeCondition(
@@ -54,10 +56,10 @@ contract AccessControlConditions is Ownable, ReentrancyGuard {
     }
 
     function storeConditionWithSigner(
-        uint key,
-        uint value,
-        uint securityHash,
-        uint chainId,
+        uint256 key,
+        uint256 value,
+        uint256 securityHash,
+        uint256 chainId,
         bool permanent,
         address creatorAddress
     ) external nonReentrant {
@@ -82,10 +84,10 @@ contract AccessControlConditions is Ownable, ReentrancyGuard {
     /* ========== PRIVATE FUNCTIONS ========== */
 
     function _storeCondition(
-        uint key,
-        uint value,
-        uint securityHash,
-        uint chainId,
+        uint256 key,
+        uint256 value,
+        uint256 securityHash,
+        uint256 chainId,
         bool permanent,
         address creatorAddress
     ) private {
@@ -116,9 +118,9 @@ contract AccessControlConditions is Ownable, ReentrancyGuard {
     /* ========== EVENTS ========== */
 
     event ConditionStored(
-        uint indexed key,
-        uint value,
-        uint chainId,
+        uint256 indexed key,
+        uint256 value,
+        uint256 chainId,
         bool permanent,
         address creator
     );

--- a/contracts/ConditionValidations.sol
+++ b/contracts/ConditionValidations.sol
@@ -24,8 +24,8 @@ Todos
 contract ConditionValidations is ReentrancyGuard {
     /* ========== STRUCTS ========== */
     struct ValidatedCondition {
-        uint chainId;
-        uint timestamp;
+        uint256 chainId;
+        uint256 timestamp;
         address creator;
     }
 
@@ -50,9 +50,11 @@ contract ConditionValidations is ReentrancyGuard {
 
     /* ========== VIEWS ========== */
 
-    function getValidatedCondition(
-        bytes32 conditionHashKey
-    ) external view returns (ValidatedCondition memory) {
+    function getValidatedCondition(bytes32 conditionHashKey)
+        external
+        view
+        returns (ValidatedCondition memory)
+    {
         // check if key exists in validatedConditions
         if (validatedConditions[conditionHashKey].timestamp != 0) {
             return validatedConditions[conditionHashKey];
@@ -61,21 +63,24 @@ contract ConditionValidations is ReentrancyGuard {
         }
     }
 
-    function verifySignature(
-        bytes32 conditionHash,
-        bytes memory signature
-    ) external view returns (bool) {
+    function verifySignature(bytes32 conditionHash, bytes memory signature)
+        external
+        view
+        returns (bool)
+    {
         address sigAddress = ECDSA.recover(conditionHash, signature);
 
         return validAddresses[sigAddress];
     }
 
-    function testPubKeyToAddress(
-        bytes memory _publicKey
-    ) external pure returns (address) {
+    function testPubKeyToAddress(bytes memory _publicKey)
+        external
+        pure
+        returns (address)
+    {
         //require(_publicKey.length == 64);
         address addrFromPublicKey = address(
-            uint160(uint(keccak256(_publicKey)))
+            uint160(uint256(keccak256(_publicKey)))
         );
 
         return addrFromPublicKey;
@@ -83,7 +88,7 @@ contract ConditionValidations is ReentrancyGuard {
 
     /* ========== MUTATIVE FUNCTIONS ========== */
     function storeValidatedCondition(
-        uint chainId,
+        uint256 chainId,
         bytes32 conditionHash,
         bytes memory signature
     ) external nonReentrant {
@@ -112,8 +117,8 @@ contract ConditionValidations is ReentrancyGuard {
 
     event ValidationStored(
         bytes32 indexed conditionHash,
-        uint chainId,
-        uint timestamp,
+        uint256 chainId,
+        uint256 timestamp,
         address creator
     );
 }

--- a/contracts/LITToken.sol
+++ b/contracts/LITToken.sol
@@ -45,7 +45,7 @@ contract LITToken is
     ///
     /// @param _recipient the account to mint tokens to.
     /// @param _amount    the amount of tokens to mint.
-    function mint(address _recipient, uint _amount) external onlyMinter {
+    function mint(address _recipient, uint256 _amount) external onlyMinter {
         _mint(_recipient, _amount);
     }
 }

--- a/contracts/Multisender.sol
+++ b/contracts/Multisender.sol
@@ -8,20 +8,19 @@ import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract Multisender is Ownable {
     function sendEth(address[] calldata _recipients) public payable {
-        uint val = msg.value / _recipients.length;
-        for (uint i = 0; i < _recipients.length; i++) {
+        uint256 val = msg.value / _recipients.length;
+        for (uint256 i = 0; i < _recipients.length; i++) {
             payable(_recipients[i]).transfer(val);
         }
     }
 
-    function sendTokens(
-        address[] calldata _recipients,
-        address tokenContract
-    ) public {
+    function sendTokens(address[] calldata _recipients, address tokenContract)
+        public
+    {
         ERC20 tkn = ERC20(tokenContract);
-        uint bal = tkn.balanceOf(address(this));
-        uint val = bal / _recipients.length;
-        for (uint i = 0; i < _recipients.length; i++) {
+        uint256 bal = tkn.balanceOf(address(this));
+        uint256 val = bal / _recipients.length;
+        for (uint256 i = 0; i < _recipients.length; i++) {
             tkn.transfer(_recipients[i], val);
         }
     }
@@ -32,7 +31,7 @@ contract Multisender is Ownable {
 
     function withdrawTokens(address tokenContract) public onlyOwner {
         ERC20 tkn = ERC20(tokenContract);
-        uint bal = tkn.balanceOf(address(this));
+        uint256 bal = tkn.balanceOf(address(this));
         tkn.transfer(msg.sender, bal);
     }
 }

--- a/contracts/PKPHelper.sol
+++ b/contracts/PKPHelper.sol
@@ -34,21 +34,21 @@ contract PKPHelper is Ownable, IERC721Receiver {
     /* ========== MUTATIVE FUNCTIONS ========== */
 
     function mintNextAndAddAuthMethods(
-        uint keyType,
-        uint[] memory permittedAuthMethodTypes,
+        uint256 keyType,
+        uint256[] memory permittedAuthMethodTypes,
         bytes[] memory permittedAuthMethodIds,
         bytes[] memory permittedAuthMethodPubkeys,
-        uint[][] memory permittedAuthMethodScopes,
+        uint256[][] memory permittedAuthMethodScopes,
         bool addPkpEthAddressAsPermittedAddress,
         bool sendPkpToItself
-    ) public payable returns (uint) {
+    ) public payable returns (uint256) {
         return
             mintNextAndAddAuthMethodsWithTypes(
                 keyType,
                 new bytes[](0), // permitted ipfs CIDs
-                new uint[][](0), // permitted ipfs CIDs scopes
+                new uint256[][](0), // permitted ipfs CIDs scopes
                 new address[](0), // permitted addresses
-                new uint[][](0), // permitted addresses scopes
+                new uint256[][](0), // permitted addresses scopes
                 permittedAuthMethodTypes,
                 permittedAuthMethodIds,
                 permittedAuthMethodPubkeys,
@@ -59,20 +59,20 @@ contract PKPHelper is Ownable, IERC721Receiver {
     }
 
     function mintNextAndAddAuthMethodsWithTypes(
-        uint keyType,
+        uint256 keyType,
         bytes[] memory permittedIpfsCIDs,
-        uint[][] memory permittedIpfsCIDScopes,
+        uint256[][] memory permittedIpfsCIDScopes,
         address[] memory permittedAddresses,
-        uint[][] memory permittedAddressScopes,
-        uint[] memory permittedAuthMethodTypes,
+        uint256[][] memory permittedAddressScopes,
+        uint256[] memory permittedAuthMethodTypes,
         bytes[] memory permittedAuthMethodIds,
         bytes[] memory permittedAuthMethodPubkeys,
-        uint[][] memory permittedAuthMethodScopes,
+        uint256[][] memory permittedAuthMethodScopes,
         bool addPkpEthAddressAsPermittedAddress,
         bool sendPkpToItself
-    ) public payable returns (uint) {
+    ) public payable returns (uint256) {
         // mint the nft and forward the funds
-        uint tokenId = pkpNFT.mintNext{value: msg.value}(keyType);
+        uint256 tokenId = pkpNFT.mintNext{value: msg.value}(keyType);
 
         // sanity checking array lengths
         require(
@@ -99,7 +99,7 @@ contract PKPHelper is Ownable, IERC721Receiver {
 
         // permit the action
         if (permittedIpfsCIDs.length != 0) {
-            for (uint i = 0; i < permittedIpfsCIDs.length; i++) {
+            for (uint256 i = 0; i < permittedIpfsCIDs.length; i++) {
                 pkpPermissions.addPermittedAction(
                     tokenId,
                     permittedIpfsCIDs[i],
@@ -110,7 +110,7 @@ contract PKPHelper is Ownable, IERC721Receiver {
 
         // permit the address
         if (permittedAddresses.length != 0) {
-            for (uint i = 0; i < permittedAddresses.length; i++) {
+            for (uint256 i = 0; i < permittedAddresses.length; i++) {
                 pkpPermissions.addPermittedAddress(
                     tokenId,
                     permittedAddresses[i],
@@ -121,12 +121,14 @@ contract PKPHelper is Ownable, IERC721Receiver {
 
         // permit the auth method
         if (permittedAuthMethodTypes.length != 0) {
-            for (uint i = 0; i < permittedAuthMethodTypes.length; i++) {
+            for (uint256 i = 0; i < permittedAuthMethodTypes.length; i++) {
                 pkpPermissions.addPermittedAuthMethod(
                     tokenId,
-                    PKPPermissions.AuthMethod(permittedAuthMethodTypes[i],
-                    permittedAuthMethodIds[i],
-                    permittedAuthMethodPubkeys[i]),
+                    PKPPermissions.AuthMethod(
+                        permittedAuthMethodTypes[i],
+                        permittedAuthMethodIds[i],
+                        permittedAuthMethodPubkeys[i]
+                    ),
                     permittedAuthMethodScopes[i]
                 );
             }
@@ -139,7 +141,7 @@ contract PKPHelper is Ownable, IERC721Receiver {
             pkpPermissions.addPermittedAddress(
                 tokenId,
                 pkpEthAddress,
-                new uint[](0)
+                new uint256[](0)
             );
         }
 
@@ -156,16 +158,17 @@ contract PKPHelper is Ownable, IERC721Receiver {
         pkpNFT = PKPNFT(newPkpNftAddress);
     }
 
-    function setPkpPermissionsAddress(
-        address newPkpPermissionsAddress
-    ) public onlyOwner {
+    function setPkpPermissionsAddress(address newPkpPermissionsAddress)
+        public
+        onlyOwner
+    {
         pkpPermissions = PKPPermissions(newPkpPermissionsAddress);
     }
 
     function onERC721Received(
-        address /* operator */,
-        address /* from */,
-        uint /* tokenId */,
+        address, /* operator */
+        address, /* from */
+        uint256, /* tokenId */
         bytes calldata /* data */
     ) external view override returns (bytes4) {
         // only accept transfers from the pkpNft contract

--- a/contracts/PKPNFT.sol
+++ b/contracts/PKPNFT.sol
@@ -36,13 +36,13 @@ contract PKPNFT is
     PubkeyRouter public router;
     PKPPermissions public pkpPermissions;
     PKPNFTMetadata public pkpNftMetadata;
-    uint public mintCost;
+    uint256 public mintCost;
     address public freeMintSigner;
 
     // maps keytype to array of unminted routed token ids
-    mapping(uint => uint[]) public unmintedRoutedTokenIds;
+    mapping(uint256 => uint256[]) public unmintedRoutedTokenIds;
 
-    mapping(uint => bool) public redeemedFreeMintIds;
+    mapping(uint256 => bool) public redeemedFreeMintIds;
 
     /* ========== CONSTRUCTOR ========== */
     constructor() {
@@ -53,18 +53,18 @@ contract PKPNFT is
     /* ========== VIEWS ========== */
 
     /// get the eth address for the keypair, as long as it's an ecdsa keypair
-    function getEthAddress(uint tokenId) public view returns (address) {
+    function getEthAddress(uint256 tokenId) public view returns (address) {
         return router.getEthAddress(tokenId);
     }
 
     /// includes the 0x04 prefix so you can pass this directly to ethers.utils.computeAddress
-    function getPubkey(uint tokenId) public view returns (bytes memory) {
+    function getPubkey(uint256 tokenId) public view returns (bytes memory) {
         return router.getPubkey(tokenId);
     }
 
     /// throws if the sig is bad or msg doesn't match
     function freeMintSigTest(
-        uint freeMintId,
+        uint256 freeMintId,
         bytes32 msgHash,
         uint8 v,
         bytes32 r,
@@ -92,9 +92,13 @@ contract PKPNFT is
         );
     }
 
-    function supportsInterface(
-        bytes4 interfaceId
-    ) public view virtual override(ERC721, ERC721Enumerable) returns (bool) {
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ERC721, ERC721Enumerable)
+        returns (bool)
+    {
         return
             interfaceId == type(IERC721Enumerable).interfaceId ||
             interfaceId == type(IERC721Metadata).interfaceId ||
@@ -104,14 +108,17 @@ contract PKPNFT is
     function _beforeTokenTransfer(
         address from,
         address to,
-        uint tokenId
+        uint256 tokenId
     ) internal virtual override(ERC721, ERC721Enumerable) {
         ERC721Enumerable._beforeTokenTransfer(from, to, tokenId);
     }
 
-    function tokenURI(
-        uint tokenId
-    ) public view override returns (string memory) {
+    function tokenURI(uint256 tokenId)
+        public
+        view
+        override
+        returns (string memory)
+    {
         console.log("getting token uri");
         bytes memory pubKey = router.getPubkey(tokenId);
         console.log("got pubkey, getting eth address");
@@ -121,9 +128,11 @@ contract PKPNFT is
         return pkpNftMetadata.tokenURI(tokenId, pubKey, ethAddress);
     }
 
-    function getUnmintedRoutedTokenIdCount(
-        uint keyType
-    ) public view returns (uint) {
+    function getUnmintedRoutedTokenIdCount(uint256 keyType)
+        public
+        view
+        returns (uint256)
+    {
         return unmintedRoutedTokenIds[keyType].length;
     }
 
@@ -135,60 +144,61 @@ contract PKPNFT is
             );
     }
 
-    function exists(uint tokenId) public view returns (bool) {
+    function exists(uint256 tokenId) public view returns (bool) {
         return _exists(tokenId);
     }
 
     /* ========== MUTATIVE FUNCTIONS ========== */
 
-    function mintNext(uint keyType) public payable returns (uint) {
+    function mintNext(uint256 keyType) public payable returns (uint256) {
         require(msg.value == mintCost, "You must pay exactly mint cost");
-        uint tokenId = _getNextTokenIdToMint(keyType);
+        uint256 tokenId = _getNextTokenIdToMint(keyType);
         _mintWithoutValueCheck(tokenId, msg.sender);
         return tokenId;
     }
 
-    function mintGrantAndBurnNext(
-        uint keyType,
-        bytes memory ipfsCID
-    ) public payable returns (uint) {
+    function mintGrantAndBurnNext(uint256 keyType, bytes memory ipfsCID)
+        public
+        payable
+        returns (uint256)
+    {
         require(msg.value == mintCost, "You must pay exactly mint cost");
-        uint tokenId = _getNextTokenIdToMint(keyType);
+        uint256 tokenId = _getNextTokenIdToMint(keyType);
         _mintWithoutValueCheck(tokenId, address(this));
-        pkpPermissions.addPermittedAction(tokenId, ipfsCID, new uint[](0));
+        pkpPermissions.addPermittedAction(tokenId, ipfsCID, new uint256[](0));
         _burn(tokenId);
         return tokenId;
     }
 
     function freeMintNext(
-        uint keyType,
-        uint freeMintId,
+        uint256 keyType,
+        uint256 freeMintId,
         bytes32 msgHash,
         uint8 v,
         bytes32 r,
         bytes32 s
-    ) public returns (uint) {
-        uint tokenId = _getNextTokenIdToMint(keyType);
+    ) public returns (uint256) {
+        uint256 tokenId = _getNextTokenIdToMint(keyType);
         freeMint(freeMintId, tokenId, msgHash, v, r, s);
         return tokenId;
     }
 
     function freeMintGrantAndBurnNext(
-        uint keyType,
-        uint freeMintId,
+        uint256 keyType,
+        uint256 freeMintId,
         bytes memory ipfsCID,
         bytes32 msgHash,
         uint8 v,
         bytes32 r,
         bytes32 s
-    ) public returns (uint) {
-        uint tokenId = _getNextTokenIdToMint(keyType);
+    ) public returns (uint256) {
+        uint256 tokenId = _getNextTokenIdToMint(keyType);
         freeMintGrantAndBurn(freeMintId, tokenId, ipfsCID, msgHash, v, r, s);
         return tokenId;
     }
 
     /// create a valid token for a given public key.
-    function mintSpecific(uint tokenId) public onlyOwner {
+    function mintSpecific(uint256 tokenId) public onlyOwner {
         _mintWithoutValueCheck(tokenId, msg.sender);
     }
 
@@ -199,18 +209,18 @@ contract PKPNFT is
     /// where you could just trust the sig that a number is prime.
     /// without this function, a user could mint a PKP, sign a bunch of junk, and then burn the
     /// PKP to make it looks like only the Lit Action can use it.
-    function mintGrantAndBurnSpecific(
-        uint tokenId,
-        bytes memory ipfsCID
-    ) public onlyOwner {
+    function mintGrantAndBurnSpecific(uint256 tokenId, bytes memory ipfsCID)
+        public
+        onlyOwner
+    {
         _mintWithoutValueCheck(tokenId, address(this));
-        pkpPermissions.addPermittedAction(tokenId, ipfsCID, new uint[](0));
+        pkpPermissions.addPermittedAction(tokenId, ipfsCID, new uint256[](0));
         _burn(tokenId);
     }
 
     function freeMint(
-        uint freeMintId,
-        uint tokenId,
+        uint256 freeMintId,
+        uint256 tokenId,
         bytes32 msgHash,
         uint8 v,
         bytes32 r,
@@ -223,8 +233,8 @@ contract PKPNFT is
     }
 
     function freeMintGrantAndBurn(
-        uint freeMintId,
-        uint tokenId,
+        uint256 freeMintId,
+        uint256 tokenId,
         bytes memory ipfsCID,
         bytes32 msgHash,
         uint8 v,
@@ -235,11 +245,11 @@ contract PKPNFT is
         freeMintSigTest(freeMintId, msgHash, v, r, s);
         _mintWithoutValueCheck(tokenId, address(this));
         redeemedFreeMintIds[freeMintId] = true;
-        pkpPermissions.addPermittedAction(tokenId, ipfsCID, new uint[](0));
+        pkpPermissions.addPermittedAction(tokenId, ipfsCID, new uint256[](0));
         _burn(tokenId);
     }
 
-    function _mintWithoutValueCheck(uint tokenId, address to) internal {
+    function _mintWithoutValueCheck(uint256 tokenId, address to) internal {
         require(router.isRouted(tokenId), "This PKP has not been routed yet");
 
         if (to == address(this)) {
@@ -251,12 +261,12 @@ contract PKPNFT is
     }
 
     /// Take a tokenId off the stack
-    function _getNextTokenIdToMint(uint keyType) internal returns (uint) {
+    function _getNextTokenIdToMint(uint256 keyType) internal returns (uint256) {
         require(
             unmintedRoutedTokenIds[keyType].length > 0,
             "There are no unminted routed token ids to mint"
         );
-        uint tokenId = unmintedRoutedTokenIds[keyType][
+        uint256 tokenId = unmintedRoutedTokenIds[keyType][
             unmintedRoutedTokenIds[keyType].length - 1
         ];
 
@@ -270,21 +280,23 @@ contract PKPNFT is
         emit RouterAddressSet(routerAddress);
     }
 
-    function setPkpNftMetadataAddress(
-        address pkpNftMetadataAddress
-    ) public onlyOwner {
+    function setPkpNftMetadataAddress(address pkpNftMetadataAddress)
+        public
+        onlyOwner
+    {
         pkpNftMetadata = PKPNFTMetadata(pkpNftMetadataAddress);
         emit PkpNftMetadataAddressSet(pkpNftMetadataAddress);
     }
 
-    function setPkpPermissionsAddress(
-        address pkpPermissionsAddress
-    ) public onlyOwner {
+    function setPkpPermissionsAddress(address pkpPermissionsAddress)
+        public
+        onlyOwner
+    {
         pkpPermissions = PKPPermissions(pkpPermissionsAddress);
         emit PkpPermissionsAddressSet(pkpPermissionsAddress);
     }
 
-    function setMintCost(uint newMintCost) public onlyOwner {
+    function setMintCost(uint256 newMintCost) public onlyOwner {
         mintCost = newMintCost;
         emit MintCostSet(newMintCost);
     }
@@ -295,14 +307,14 @@ contract PKPNFT is
     }
 
     function withdraw() public onlyOwner nonReentrant {
-        uint withdrawAmount = address(this).balance;
+        uint256 withdrawAmount = address(this).balance;
         (bool sent, ) = payable(msg.sender).call{value: withdrawAmount}("");
         require(sent);
         emit Withdrew(withdrawAmount);
     }
 
     /// Push a tokenId onto the stack
-    function pkpRouted(uint tokenId, uint keyType) public {
+    function pkpRouted(uint256 tokenId, uint256 keyType) public {
         require(
             msg.sender == address(router),
             "Only the routing contract can call this function"
@@ -316,8 +328,8 @@ contract PKPNFT is
     event RouterAddressSet(address indexed routerAddress);
     event PkpNftMetadataAddressSet(address indexed pkpNftMetadataAddress);
     event PkpPermissionsAddressSet(address indexed pkpPermissionsAddress);
-    event MintCostSet(uint newMintCost);
+    event MintCostSet(uint256 newMintCost);
     event FreeMintSignerSet(address indexed newFreeMintSigner);
-    event Withdrew(uint amount);
-    event PkpRouted(uint indexed tokenId, uint indexed keyType);
+    event Withdrew(uint256 amount);
+    event PkpRouted(uint256 indexed tokenId, uint256 indexed keyType);
 }

--- a/contracts/PKPNFTMetadata.sol
+++ b/contracts/PKPNFTMetadata.sol
@@ -14,7 +14,7 @@ import "hardhat/console.sol";
 /// The owner can also grant signing permissions to other eth addresses
 /// or lit actions
 contract PKPNFTMetadata {
-    using Strings for uint;
+    using Strings for uint256;
 
     /* ========== STATE VARIABLES ========== */
 
@@ -33,7 +33,7 @@ contract PKPNFTMetadata {
 
         bytes memory _base = "0123456789abcdef";
 
-        for (uint i = 0; i < buffer.length; i++) {
+        for (uint256 i = 0; i < buffer.length; i++) {
             converted[i * 2] = _base[uint8(buffer[i]) / _base.length];
             converted[i * 2 + 1] = _base[uint8(buffer[i]) % _base.length];
         }
@@ -42,7 +42,7 @@ contract PKPNFTMetadata {
     }
 
     function tokenURI(
-        uint tokenId,
+        uint256 tokenId,
         bytes memory pubKey,
         address ethAddress
     ) public pure returns (string memory) {

--- a/contracts/RateLimitNFT.sol
+++ b/contracts/RateLimitNFT.sol
@@ -22,22 +22,22 @@ contract RateLimitNFT is
     ERC721Enumerable,
     ReentrancyGuard
 {
-    using Strings for uint;
+    using Strings for uint256;
     /* ========== STATE VARIABLES ========== */
 
     address public freeMintSigner;
-    uint public additionalRequestsPerMillisecondCost;
-    uint public tokenIdCounter;
-    uint public defaultRateLimitWindowMilliseconds = 60 * 60 * 1000; // 60 mins
-    uint public RLIHolderRateLimitWindowMilliseconds = 5 * 60 * 1000; // 5 mins
-    uint public freeRequestsPerRateLimitWindow = 10;
+    uint256 public additionalRequestsPerMillisecondCost;
+    uint256 public tokenIdCounter;
+    uint256 public defaultRateLimitWindowMilliseconds = 60 * 60 * 1000; // 60 mins
+    uint256 public RLIHolderRateLimitWindowMilliseconds = 5 * 60 * 1000; // 5 mins
+    uint256 public freeRequestsPerRateLimitWindow = 10;
 
-    mapping(uint => RateLimit) public capacity;
+    mapping(uint256 => RateLimit) public capacity;
     mapping(bytes32 => bool) public redeemedFreeMints;
 
     struct RateLimit {
-        uint requestsPerMillisecond;
-        uint expiresAt;
+        uint256 requestsPerMillisecond;
+        uint256 expiresAt;
     }
 
     /* ========== CONSTRUCTOR ========== */
@@ -49,8 +49,8 @@ contract RateLimitNFT is
 
     /// throws if the sig is bad or msg doesn't match
     function freeMintSigTest(
-        uint expiresAt,
-        uint requestsPerMillisecond,
+        uint256 expiresAt,
+        uint256 requestsPerMillisecond,
         bytes32 msgHash,
         uint8 v,
         bytes32 r,
@@ -83,9 +83,13 @@ contract RateLimitNFT is
         );
     }
 
-    function supportsInterface(
-        bytes4 interfaceId
-    ) public view virtual override(ERC721, ERC721Enumerable) returns (bool) {
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ERC721, ERC721Enumerable)
+        returns (bool)
+    {
         return
             interfaceId == type(IERC721Enumerable).interfaceId ||
             interfaceId == type(IERC721Metadata).interfaceId ||
@@ -95,53 +99,58 @@ contract RateLimitNFT is
     function _beforeTokenTransfer(
         address from,
         address to,
-        uint tokenId
+        uint256 tokenId
     ) internal virtual override(ERC721, ERC721Enumerable) {
         ERC721Enumerable._beforeTokenTransfer(from, to, tokenId);
     }
 
-    function calculateCost(
-        uint requestsPerMillisecond,
-        uint expiresAt
-    ) public view returns (uint) {
+    function calculateCost(uint256 requestsPerMillisecond, uint256 expiresAt)
+        public
+        view
+        returns (uint256)
+    {
         require(
             expiresAt > block.timestamp,
             "The expiresAt must be in the future"
         );
 
         // calculate the duration
-        uint durationInMilliseconds = (expiresAt - block.timestamp) * 1000;
+        uint256 durationInMilliseconds = (expiresAt - block.timestamp) * 1000;
 
         // calculate the cost
-        uint cost = requestsPerMillisecond *
+        uint256 cost = requestsPerMillisecond *
             durationInMilliseconds *
             additionalRequestsPerMillisecondCost;
 
         return cost;
     }
 
-    function calculateRequestsPerSecond(
-        uint payingAmount,
-        uint expiresAt
-    ) public view returns (uint) {
+    function calculateRequestsPerSecond(uint256 payingAmount, uint256 expiresAt)
+        public
+        view
+        returns (uint256)
+    {
         require(
             expiresAt > block.timestamp,
             "The expiresAt must be in the future"
         );
 
         // calculate the duration
-        uint durationInMilliseconds = (expiresAt - block.timestamp) * 1000;
+        uint256 durationInMilliseconds = (expiresAt - block.timestamp) * 1000;
 
         // calculate the cost
-        uint requestsPerSecond = payingAmount /
+        uint256 requestsPerSecond = payingAmount /
             (durationInMilliseconds * additionalRequestsPerMillisecondCost);
 
         return requestsPerSecond;
     }
 
-    function tokenURI(
-        uint tokenId
-    ) public view override returns (string memory) {
+    function tokenURI(uint256 tokenId)
+        public
+        view
+        override
+        returns (string memory)
+    {
         string
             memory svgData = "<svg xmlns='http://www.w3.org/2000/svg' width='1080' height='1080' fill='none' xmlns:v='https://vecta.io/nano'><path d='M363.076 392.227s-.977 18.524-36.874 78.947c-41.576 70.018-45.481 151.978-3.017 220.4 89.521 144.245 332.481 141.52 422.556.089 34.832-54.707 44.816-117.479 32.924-181.248 0 0-28.819-133.144-127.237-217.099 1.553 1.308 5.369 19.122 6.101 26.722 2.241 23.354.045 47.838-7.787 70.062-5.746 16.33-13.711 30.467-27.178 41.368 0-3.811-.954-10.635-.976-12.918-.644-46.508-18.659-89.582-48.011-125.743-25.647-31.552-60.812-53.089-97.84-68.932.931 3.191 2.662 16.419 2.906 19.033 1.908 21.958 2.263 52.713-.621 74.649s-7.832 33.878-14.554 54.441c-10.184 31.175-24.05 54.285-41.621 82.004-3.24 5.096-12.913 19.078-18.082 26.146 0 0-8.897-56.191-40.667-87.921h-.022z' fill='#000'/><path d='M562.5 27.28l410.279 236.874c13.923 8.039 22.5 22.895 22.5 38.971v473.75c0 16.076-8.577 30.932-22.5 38.971L562.5 1052.72c-13.923 8.04-31.077 8.04-45 0L107.221 815.846c-13.923-8.039-22.5-22.895-22.5-38.971v-473.75a45 45 0 0 1 22.5-38.971L517.5 27.28a45 45 0 0 1 45 0z' stroke='#000' stroke-width='24.75'/></svg>";
 
@@ -163,7 +172,7 @@ contract RateLimitNFT is
         return string(abi.encodePacked("data:application/json;base64,", json));
     }
 
-    function isExpired(uint tokenId) public view returns (bool) {
+    function isExpired(uint256 tokenId) public view returns (bool) {
         return capacity[tokenId].expiresAt <= block.timestamp;
     }
 
@@ -178,17 +187,17 @@ contract RateLimitNFT is
     /* ========== MUTATIVE FUNCTIONS ========== */
 
     /// mint a token with a certain number of requests per millisecond and a certain expiration time.  Requests per second is calculated from the msg.value amount.  You can find out the cost for a certain requests per second value by using the calculateCost() function.
-    function mint(uint expiresAt) public payable {
+    function mint(uint256 expiresAt) public payable {
         tokenIdCounter++;
-        uint tokenId = tokenIdCounter;
+        uint256 tokenId = tokenIdCounter;
 
-        uint requestsPerMillisecond = calculateRequestsPerSecond(
+        uint256 requestsPerMillisecond = calculateRequestsPerSecond(
             msg.value,
             expiresAt
         );
 
         // sanity check
-        uint cost = calculateCost(requestsPerMillisecond, expiresAt);
+        uint256 cost = calculateCost(requestsPerMillisecond, expiresAt);
         require(
             msg.value > 0 && msg.value >= cost,
             "You must send the cost of this rate limit increase.  To check the cost, use the calculateCost function."
@@ -198,15 +207,15 @@ contract RateLimitNFT is
     }
 
     function freeMint(
-        uint expiresAt,
-        uint requestsPerMillisecond,
+        uint256 expiresAt,
+        uint256 requestsPerMillisecond,
         bytes32 msgHash,
         uint8 v,
         bytes32 r,
         bytes32 s
     ) public {
         tokenIdCounter++;
-        uint tokenId = tokenIdCounter;
+        uint256 tokenId = tokenIdCounter;
 
         // this will panic if the sig is bad
         freeMintSigTest(expiresAt, requestsPerMillisecond, msgHash, v, r, s);
@@ -216,16 +225,16 @@ contract RateLimitNFT is
     }
 
     function _mintWithoutValueCheck(
-        uint tokenId,
-        uint requestsPerMillisecond,
-        uint expiresAt
+        uint256 tokenId,
+        uint256 requestsPerMillisecond,
+        uint256 expiresAt
     ) internal {
         _safeMint(msg.sender, tokenId);
         capacity[tokenId] = RateLimit(requestsPerMillisecond, expiresAt);
     }
 
     function setAdditionalRequestsPerSecondCost(
-        uint newAdditionalRequestsPerMillisecondCost
+        uint256 newAdditionalRequestsPerMillisecondCost
     ) public onlyOwner {
         additionalRequestsPerMillisecondCost = newAdditionalRequestsPerMillisecondCost;
         emit AdditionalRequestsPerSecondCostSet(
@@ -239,21 +248,21 @@ contract RateLimitNFT is
     }
 
     function withdraw() public onlyOwner nonReentrant {
-        uint withdrawAmount = address(this).balance;
+        uint256 withdrawAmount = address(this).balance;
         (bool sent, ) = payable(msg.sender).call{value: withdrawAmount}("");
         require(sent);
         emit Withdrew(withdrawAmount);
     }
 
     function setRateLimitWindowMilliseconds(
-        uint newRateLimitWindowMilliseconds
+        uint256 newRateLimitWindowMilliseconds
     ) public onlyOwner {
         defaultRateLimitWindowMilliseconds = newRateLimitWindowMilliseconds;
         emit RateLimitWindowMillisecondsSet(newRateLimitWindowMilliseconds);
     }
 
     function setRLIHolderRateLimitWindowMilliseconds(
-        uint newRLIHolderRateLimitWindowMilliseconds
+        uint256 newRLIHolderRateLimitWindowMilliseconds
     ) public onlyOwner {
         RLIHolderRateLimitWindowMilliseconds = newRLIHolderRateLimitWindowMilliseconds;
         emit RLIHolderRateLimitWindowMillisecondsSet(
@@ -262,7 +271,7 @@ contract RateLimitNFT is
     }
 
     function setFreeRequestsPerRateLimitWindow(
-        uint newFreeRequestsPerRateLimitWindow
+        uint256 newFreeRequestsPerRateLimitWindow
     ) public onlyOwner {
         freeRequestsPerRateLimitWindow = newFreeRequestsPerRateLimitWindow;
         emit FreeRequestsPerRateLimitWindowSet(
@@ -273,15 +282,17 @@ contract RateLimitNFT is
     /* ========== EVENTS ========== */
 
     event AdditionalRequestsPerSecondCostSet(
-        uint newAdditionalRequestsPerMillisecondCost
+        uint256 newAdditionalRequestsPerMillisecondCost
     );
     event FreeMintSignerSet(address indexed newFreeMintSigner);
-    event Withdrew(uint amount);
-    event RateLimitWindowMillisecondsSet(uint newRateLimitWindowMilliseconds);
+    event Withdrew(uint256 amount);
+    event RateLimitWindowMillisecondsSet(
+        uint256 newRateLimitWindowMilliseconds
+    );
     event RLIHolderRateLimitWindowMillisecondsSet(
-        uint newRLIHolderRateLimitWindowMilliseconds
+        uint256 newRLIHolderRateLimitWindowMilliseconds
     );
     event FreeRequestsPerRateLimitWindowSet(
-        uint newFreeRequestsPerRateLimitWindow
+        uint256 newFreeRequestsPerRateLimitWindow
     );
 }

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -38,21 +38,21 @@ contract Staking is ReentrancyGuard, Pausable, Ownable {
     LITToken public stakingToken;
 
     struct Epoch {
-        uint epochLength;
-        uint number;
-        uint endBlock; //
-        uint retries; // incremented upon failure to advance and subsequent unlock
+        uint256 epochLength;
+        uint256 number;
+        uint256 endBlock; //
+        uint256 retries; // incremented upon failure to advance and subsequent unlock
     }
 
     Epoch public epoch;
 
-    uint public tokenRewardPerTokenPerEpoch;
+    uint256 public tokenRewardPerTokenPerEpoch;
 
-    uint public minimumStake;
-    uint public totalStaked;
+    uint256 public minimumStake;
+    uint256 public totalStaked;
 
     // tokens slashed when kicked
-    uint public kickPenaltyPercent;
+    uint256 public kickPenaltyPercent;
 
     EnumerableSet.AddressSet validatorsInCurrentEpoch;
     EnumerableSet.AddressSet validatorsInNextEpoch;
@@ -63,14 +63,14 @@ contract Staking is ReentrancyGuard, Pausable, Ownable {
         uint128 ipv6;
         uint32 port;
         address nodeAddress;
-        uint balance;
-        uint reward;
-        uint senderPubKey;
-        uint receiverPubKey;
+        uint256 balance;
+        uint256 reward;
+        uint256 senderPubKey;
+        uint256 receiverPubKey;
     }
 
     struct VoteToKickValidatorInNextEpoch {
-        uint votes;
+        uint256 votes;
         mapping(address => bool) voted;
     }
 
@@ -91,7 +91,7 @@ contract Staking is ReentrancyGuard, Pausable, Ownable {
 
     // nodes can vote to kick another node.  If a threshold of nodes vote to kick someone, they
     // are removed from the next validator set
-    mapping(uint => mapping(address => VoteToKickValidatorInNextEpoch))
+    mapping(uint256 => mapping(address => VoteToKickValidatorInNextEpoch))
         public votesToKickValidatorsInNextEpoch;
 
     // resolver contract address. the resolver contract is used to lookup other contract addresses.
@@ -107,9 +107,9 @@ contract Staking is ReentrancyGuard, Pausable, Ownable {
             retries: 0
         });
         // 0.05 tokens per token staked meaning a 5% per epoch inflation rate
-        tokenRewardPerTokenPerEpoch = (10 ** stakingToken.decimals()) / 20;
+        tokenRewardPerTokenPerEpoch = (10**stakingToken.decimals()) / 20;
         // 1 token minimum stake
-        minimumStake = 1 * (10 ** stakingToken.decimals());
+        minimumStake = 1 * (10**stakingToken.decimals());
         kickPenaltyPercent = 5;
     }
 
@@ -118,19 +118,19 @@ contract Staking is ReentrancyGuard, Pausable, Ownable {
         return validatorsInCurrentEpoch.contains(account);
     }
 
-    function rewardOf(address account) external view returns (uint) {
+    function rewardOf(address account) external view returns (uint256) {
         return validators[account].reward;
     }
 
-    function balanceOf(address account) external view returns (uint) {
+    function balanceOf(address account) external view returns (uint256) {
         return validators[account].balance;
     }
 
     function getVotingStatusToKickValidator(
-        uint epochNumber,
+        uint256 epochNumber,
         address validatorStakerAddress,
         address voterStakerAddress
-    ) external view returns (uint, bool) {
+    ) external view returns (uint256, bool) {
         VoteToKickValidatorInNextEpoch
             storage votingStatus = votesToKickValidatorsInNextEpoch[
                 epochNumber
@@ -146,8 +146,8 @@ contract Staking is ReentrancyGuard, Pausable, Ownable {
         address[] memory values = new address[](
             validatorsInCurrentEpoch.length()
         );
-        uint validatorLength = validatorsInCurrentEpoch.length();
-        for (uint i = 0; i < validatorLength; i++) {
+        uint256 validatorLength = validatorsInCurrentEpoch.length();
+        for (uint256 i = 0; i < validatorLength; i++) {
             values[i] = validatorsInCurrentEpoch.at(i);
         }
         return values;
@@ -159,17 +159,17 @@ contract Staking is ReentrancyGuard, Pausable, Ownable {
         returns (address[] memory)
     {
         address[] memory values = new address[](validatorsInNextEpoch.length());
-        uint validatorLength = validatorsInNextEpoch.length();
-        for (uint i = 0; i < validatorLength; i++) {
+        uint256 validatorLength = validatorsInNextEpoch.length();
+        for (uint256 i = 0; i < validatorLength; i++) {
             values[i] = validatorsInNextEpoch.at(i);
         }
         return values;
     }
 
     function isReadyForNextEpoch() public view returns (bool) {
-        uint total = 0;
-        uint validatorLength = validatorsInNextEpoch.length();
-        for (uint i = 0; i < validatorLength; i++) {
+        uint256 total = 0;
+        uint256 validatorLength = validatorsInNextEpoch.length();
+        for (uint256 i = 0; i < validatorLength; i++) {
             if (readyForNextEpoch[validatorsInNextEpoch.at(i)]) {
                 total++;
             }
@@ -181,9 +181,11 @@ contract Staking is ReentrancyGuard, Pausable, Ownable {
         return false;
     }
 
-    function shouldKickValidator(
-        address stakerAddress
-    ) public view returns (bool) {
+    function shouldKickValidator(address stakerAddress)
+        public
+        view
+        returns (bool)
+    {
         VoteToKickValidatorInNextEpoch
             storage vk = votesToKickValidatorsInNextEpoch[epoch.number][
                 stakerAddress
@@ -209,7 +211,7 @@ contract Staking is ReentrancyGuard, Pausable, Ownable {
     }
 
     // currently set to 2/3.  this could be changed to be configurable.
-    function validatorCountForConsensus() public view returns (uint) {
+    function validatorCountForConsensus() public view returns (uint256) {
         if (validatorsInCurrentEpoch.length() <= 2) {
             return 1;
         }
@@ -269,8 +271,8 @@ contract Staking is ReentrancyGuard, Pausable, Ownable {
             "Must be in NextValidatorSetLocked"
         );
 
-        uint validatorLength = validatorsInNextEpoch.length();
-        for (uint i = 0; i < validatorLength; i++) {
+        uint256 validatorLength = validatorsInNextEpoch.length();
+        for (uint256 i = 0; i < validatorLength; i++) {
             readyForNextEpoch[validatorsInNextEpoch.at(i)] = false;
         }
 
@@ -297,13 +299,13 @@ contract Staking is ReentrancyGuard, Pausable, Ownable {
         );
 
         // reward the validators
-        uint validatorLength = validatorsInCurrentEpoch.length();
-        for (uint i = 0; i < validatorLength; i++) {
+        uint256 validatorLength = validatorsInCurrentEpoch.length();
+        for (uint256 i = 0; i < validatorLength; i++) {
             address validatorAddress = validatorsInCurrentEpoch.at(i);
             validators[validatorAddress].reward +=
                 (tokenRewardPerTokenPerEpoch *
                     validators[validatorAddress].balance) /
-                10 ** stakingToken.decimals();
+                10**stakingToken.decimals();
         }
 
         // set the validators to the new validator set
@@ -318,7 +320,7 @@ contract Staking is ReentrancyGuard, Pausable, Ownable {
 
         // copy validators from next epoch to current epoch
         validatorLength = validatorsInNextEpoch.length();
-        for (uint i = 0; i < validatorLength; i++) {
+        for (uint256 i = 0; i < validatorLength; i++) {
             validatorsInCurrentEpoch.add(validatorsInNextEpoch.at(i));
 
             // clear out readyForNextEpoch
@@ -337,13 +339,13 @@ contract Staking is ReentrancyGuard, Pausable, Ownable {
     /// @param ip The IP address of the node
     /// @param port The port of the node
     function stakeAndJoin(
-        uint amount,
+        uint256 amount,
         uint32 ip,
         uint128 ipv6,
         uint32 port,
         address nodeAddress,
-        uint senderPubKey,
-        uint receiverPubKey
+        uint256 senderPubKey,
+        uint256 receiverPubKey
     ) public whenNotPaused {
         stake(amount);
         requestToJoin(
@@ -357,7 +359,7 @@ contract Staking is ReentrancyGuard, Pausable, Ownable {
     }
 
     /// Stake tokens for a validator
-    function stake(uint amount) public nonReentrant {
+    function stake(uint256 amount) public nonReentrant {
         require(amount > 0, "Cannot stake 0");
 
         stakingToken.safeTransferFrom(msg.sender, address(this), amount);
@@ -373,10 +375,10 @@ contract Staking is ReentrancyGuard, Pausable, Ownable {
         uint128 ipv6,
         uint32 port,
         address nodeAddress,
-        uint senderPubKey,
-        uint receiverPubKey
+        uint256 senderPubKey,
+        uint256 receiverPubKey
     ) public nonReentrant {
-        uint amountStaked = validators[msg.sender].balance;
+        uint256 amountStaked = validators[msg.sender].balance;
         require(
             amountStaked >= minimumStake,
             "Stake must be greater than or equal to minimumStake"
@@ -407,7 +409,7 @@ contract Staking is ReentrancyGuard, Pausable, Ownable {
 
     /// Withdraw staked tokens.  This can only be done by users who are not active in the validator set.
     /// @param amount The amount of tokens to withdraw
-    function withdraw(uint amount) public nonReentrant {
+    function withdraw(uint256 amount) public nonReentrant {
         require(amount > 0, "Cannot withdraw 0");
 
         require(
@@ -443,7 +445,7 @@ contract Staking is ReentrancyGuard, Pausable, Ownable {
 
     /// Transfer any outstanding reward tokens
     function getReward() public nonReentrant {
-        uint reward = validators[msg.sender].reward;
+        uint256 reward = validators[msg.sender].reward;
         if (reward > 0) {
             validators[msg.sender].reward = 0;
             stakingToken.safeTransfer(msg.sender, reward);
@@ -461,7 +463,7 @@ contract Staking is ReentrancyGuard, Pausable, Ownable {
     /// It's expected that this will be called by the node directly, so msg.sender will be the nodeAddress
     function kickValidatorInNextEpoch(
         address validatorStakerAddress,
-        uint reason,
+        uint256 reason,
         bytes calldata data
     ) public nonReentrant {
         address stakerAddressOfSender = nodeAddressToStakerAddress[msg.sender];
@@ -495,7 +497,7 @@ contract Staking is ReentrancyGuard, Pausable, Ownable {
             // block them from rejoining the next epoch
             validatorsKickedFromNextEpoch.add(validatorStakerAddress);
             // slash the stake
-            uint amountToBurn = (validators[validatorStakerAddress].balance *
+            uint256 amountToBurn = (validators[validatorStakerAddress].balance *
                 kickPenaltyPercent) / 100;
             validators[validatorStakerAddress].balance -= amountToBurn;
             totalStaked -= amountToBurn;
@@ -520,8 +522,8 @@ contract Staking is ReentrancyGuard, Pausable, Ownable {
         uint128 ipv6,
         uint32 port,
         address nodeAddress,
-        uint senderPubKey,
-        uint receiverPubKey
+        uint256 senderPubKey,
+        uint256 receiverPubKey
     ) public {
         validators[msg.sender].ip = ip;
         validators[msg.sender].ipv6 = ipv6;
@@ -531,7 +533,7 @@ contract Staking is ReentrancyGuard, Pausable, Ownable {
         validators[msg.sender].receiverPubKey = receiverPubKey;
     }
 
-    function setEpochLength(uint newEpochLength) public onlyOwner {
+    function setEpochLength(uint256 newEpochLength) public onlyOwner {
         epoch.epochLength = newEpochLength;
         emit EpochLengthSet(newEpochLength);
     }
@@ -542,27 +544,29 @@ contract Staking is ReentrancyGuard, Pausable, Ownable {
     }
 
     function setTokenRewardPerTokenPerEpoch(
-        uint newTokenRewardPerTokenPerEpoch
+        uint256 newTokenRewardPerTokenPerEpoch
     ) public onlyOwner {
         tokenRewardPerTokenPerEpoch = newTokenRewardPerTokenPerEpoch;
         emit TokenRewardPerTokenPerEpochSet(newTokenRewardPerTokenPerEpoch);
     }
 
-    function setMinimumStake(uint newMinimumStake) public onlyOwner {
+    function setMinimumStake(uint256 newMinimumStake) public onlyOwner {
         minimumStake = newMinimumStake;
         emit MinimumStakeSet(newMinimumStake);
     }
 
-    function setKickPenaltyPercent(
-        uint newKickPenaltyPercent
-    ) public onlyOwner {
+    function setKickPenaltyPercent(uint256 newKickPenaltyPercent)
+        public
+        onlyOwner
+    {
         kickPenaltyPercent = newKickPenaltyPercent;
         emit KickPenaltyPercentSet(newKickPenaltyPercent);
     }
 
-    function setResolverContractAddress(
-        address newResolverContractAddress
-    ) public onlyOwner {
+    function setResolverContractAddress(address newResolverContractAddress)
+        public
+        onlyOwner
+    {
         resolverContractAddress = newResolverContractAddress;
 
         emit ResolverContractAddressSet(newResolverContractAddress);
@@ -570,28 +574,30 @@ contract Staking is ReentrancyGuard, Pausable, Ownable {
 
     /* ========== EVENTS ========== */
 
-    event Staked(address indexed staker, uint amount);
-    event Withdrawn(address indexed staker, uint amount);
-    event RewardPaid(address indexed staker, uint reward);
-    event RewardsDurationUpdated(uint newDuration);
+    event Staked(address indexed staker, uint256 amount);
+    event Withdrawn(address indexed staker, uint256 amount);
+    event RewardPaid(address indexed staker, uint256 reward);
+    event RewardsDurationUpdated(uint256 newDuration);
     event RequestToJoin(address indexed staker);
     event RequestToLeave(address indexed staker);
-    event Recovered(address token, uint amount);
+    event Recovered(address token, uint256 amount);
     event ReadyForNextEpoch(address indexed staker);
     event StateChanged(States newState);
     event VotedToKickValidatorInNextEpoch(
         address indexed reporter,
         address indexed validatorStakerAddress,
-        uint indexed reason,
+        uint256 indexed reason,
         bytes data
     );
     event ValidatorKickedFromNextEpoch(address indexed staker);
 
     // onlyOwner events
-    event EpochLengthSet(uint newEpochLength);
+    event EpochLengthSet(uint256 newEpochLength);
     event StakingTokenSet(address newStakingTokenAddress);
-    event TokenRewardPerTokenPerEpochSet(uint newTokenRewardPerTokenPerEpoch);
-    event MinimumStakeSet(uint newMinimumStake);
-    event KickPenaltyPercentSet(uint newKickPenaltyPercent);
+    event TokenRewardPerTokenPerEpochSet(
+        uint256 newTokenRewardPerTokenPerEpoch
+    );
+    event MinimumStakeSet(uint256 newMinimumStake);
+    event KickPenaltyPercentSet(uint256 newKickPenaltyPercent);
     event ResolverContractAddressSet(address newResolverContractAddress);
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "compile": "npx hardhat compile",
     "convertPubkey": "node pubkeyToRoutingData.js",
     "convertIpfsId": "node ipfsIdToParts.js",
-    "hashIpfsId": "node ipfsIdToHash.js"
+    "hashIpfsId": "node ipfsIdToHash.js",
+    "prettier": "prettier -c -w '**/*.js' '**/*.sol' '**/*.md'"
   },
   "devDependencies": {
     "@defi-wonderland/smock": "^2.1.0",

--- a/scripts/deploy_PKP_and_Router.js
+++ b/scripts/deploy_PKP_and_Router.js
@@ -3,9 +3,9 @@
 //
 // When running the script with `hardhat run <script>` you'll find the Hardhat
 // Runtime Environment's members available in the global scope.
-const hre = require('hardhat')
+const hre = require("hardhat");
 
-async function main () {
+async function main() {
   // Hardhat always runs the compile task when running scripts with its command
   // line interface.
   //
@@ -15,18 +15,21 @@ async function main () {
 
   // this can be removed if Ethernal isn't being used - it's handy to see validations.
   // Ethernal set up instructions:  https://www.tryethernal.com
-  // In the hardhat.config.js file >>>  require('hardhat-ethernal'); 
+  // In the hardhat.config.js file >>>  require('hardhat-ethernal');
   hre.ethernalUploadAst = true; // clean and reset the workspace - ie, forget about old contracts, and start fresh.
-  await  hre.ethernal.resetWorkspace('LocalHardHat');  /// <<< your ethernal project name.
+  await hre.ethernal.resetWorkspace("LocalHardHat"); /// <<< your ethernal project name.
 
   let RouterContractFactory;
   let TokenContractFactory;
   let TokenContract;
-  
-  // make this a public key that the nodes have generated.
-  let pubkey = '0x034319b040a81f78d14b8efcf73f3120b28d88ac5ca316dbd1a83797defcf20b5a';       
 
-  RouterContractFactory = await ethers.getContractFactory("PubkeyRouterAndPermissions");
+  // make this a public key that the nodes have generated.
+  let pubkey =
+    "0x034319b040a81f78d14b8efcf73f3120b28d88ac5ca316dbd1a83797defcf20b5a";
+
+  RouterContractFactory = await ethers.getContractFactory(
+    "PubkeyRouterAndPermissions"
+  );
   TokenContractFactory = await ethers.getContractFactory("PKPNFT");
 
   [deployer, holder, ...signers] = await ethers.getSigners();
@@ -34,36 +37,40 @@ async function main () {
   // deploy the PKP contract
   TokenContract = await TokenContractFactory.deploy();
   await TokenContract.deployed();
-  console.log('Contract for PKPNFT deployed to:', TokenContract.address)
+  console.log("Contract for PKPNFT deployed to:", TokenContract.address);
 
   await TokenContract.connect(deployer);
-  
 
   // Deploy the router contract.
   routerContract = await RouterContractFactory.deploy(TokenContract.address);
   await routerContract.deployed();
-  console.log('Contract for PubkeyRouterAndPermissions deployed to:', routerContract.address)
+  console.log(
+    "Contract for PubkeyRouterAndPermissions deployed to:",
+    routerContract.address
+  );
 
   // mint a token
-  const txn = await TokenContract.mint(pubkey);    
-  const tx = await txn.wait(); 
+  const txn = await TokenContract.mint(pubkey);
+  const tx = await txn.wait();
   const event = tx.events[0];
   const tokenId = event.args[2];
   const token_address = event.address;
 
   // transfer the token to a known wallet :
-  await TokenContract.transfer(deployer.address,  holder.address, tokenId);  // In this case using HardHat Accounnt #1
-
+  await TokenContract.transfer(deployer.address, holder.address, tokenId); // In this case using HardHat Accounnt #1
 
   const pubkeyHash = ethers.utils.keccak256(pubkey);
 
   // validate that it's unset
   const [keyPart1, keyPart2, keyLength, stakingContract, keyType] =
-  await routerContract.getRoutingData(pubkeyHash);
+    await routerContract.getRoutingData(pubkeyHash);
 
   // set routing data
   const keyPart1Bytes = ethers.utils.hexDataSlice(pubkeyHash, 0, 32);
-  const keyPart2Bytes = ethers.utils.hexZeroPad( ethers.utils.hexDataSlice(pubkeyHash, 32), 32  );
+  const keyPart2Bytes = ethers.utils.hexZeroPad(
+    ethers.utils.hexDataSlice(pubkeyHash, 32),
+    32
+  );
 
   const stakingContractAddress = "0x6cB3Cd5064692ac8e3368A1d6C29b36aE1143dF7"; // a random address, since we haven't tied it in but it's a required field - dependency for go-live!
   const keyLengthInput = 48;
@@ -87,24 +94,22 @@ async function main () {
     keyTypeAfter,
   ] = await routerContract.getRoutingData(pubkeyHash);
 
-  console.log('Confirming that we have storage: ', keyPart1After);
+  console.log("Confirming that we have storage: ", keyPart1After);
 
-
-
-   // Get contract ASTs into ethernal
-   // Doing this at the end because it can be a bit slow, and we can validate other things at the same time.
-  await hre.ethernal.push({name:'PubkeyRouterAndPermissions', address: routerContract.address});
-  await hre.ethernal.push({name:'PKPNFT', address: TokenContract.address});
-
-
+  // Get contract ASTs into ethernal
+  // Doing this at the end because it can be a bit slow, and we can validate other things at the same time.
+  await hre.ethernal.push({
+    name: "PubkeyRouterAndPermissions",
+    address: routerContract.address,
+  });
+  await hre.ethernal.push({ name: "PKPNFT", address: TokenContract.address });
 }
 
 // We recommend this pattern to be able to use async/await everywhere
 // and properly handle errors.
 main()
   .then(() => process.exit(0))
-  .catch(error => {
-    console.error(error)
-    process.exit(1)
-  })
-
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/scripts/deploy_all.js
+++ b/scripts/deploy_all.js
@@ -3,95 +3,137 @@
 //
 // When running the script with `hardhat run <script>` you'll find the Hardhat
 // Runtime Environment's members available in the global scope.
-const hre = require('hardhat')
+const hre = require("hardhat");
 const { ip2int, int2ip } = require("../utils.js");
-const fs = require('fs');
-require('hardhat-ethernal'); // required for ethernal - removing this will only break deploy scripts that are linked to ethernal .
-require('dotenv').config();
+const fs = require("fs");
+require("hardhat-ethernal"); // required for ethernal - removing this will only break deploy scripts that are linked to ethernal .
+require("dotenv").config();
 
 // quick & dirty config writing helper!
 let nodeFileId = 1;
-const f = (n , v) =>  {
-  if (v) {  n = n + v };
-  fs.appendFileSync('lit_config' + nodeFileId + '.env', n + '\n', err => { 
-    if (err) { console.error(err)}}
-    );
-}
+const f = (n, v) => {
+  if (v) {
+    n = n + v;
+  }
+  fs.appendFileSync("lit_config" + nodeFileId + ".env", n + "\n", (err) => {
+    if (err) {
+      console.error(err);
+    }
+  });
+};
 
-async function main () {
-
+async function main() {
   // ethernal config
   hre.ethernalUploadAst = true;
   hre.ethernal.UploadAst = true; // allow contract uploading.
   hre.ethernal.AstUpload = true;
-  await  hre.ethernal.resetWorkspace('LocalHardHat');  /// <<< your ethernal project name.
+  await hre.ethernal.resetWorkspace("LocalHardHat"); /// <<< your ethernal project name.
 
   // we really only need a single deployer & are using HH accounts, but could override this to deploy to a public chain.
-  [deployer, ...signers] = await hre.ethers.getSigners()
+  [deployer, ...signers] = await hre.ethers.getSigners();
 
   // Deploy Contracts
   console.log("\n\nDeploying contracts : ");
-  console.log('Deployer Account:', deployer.address)
+  console.log("Deployer Account:", deployer.address);
 
   // Deploy Access Control Conditions
-  const f_AccessCtlConditions = await hre.ethers.getContractFactory('AccessControlConditions', {signer : deployer} );
-  const c_AccessCtlConditions = await  f_AccessCtlConditions.deploy();  /// currently the owner address is hardcoded.  To be replaced by public keys.
-  await c_AccessCtlConditions.deployed()
-  console.log('Contract for AccessControlConditions deployed to:', c_AccessCtlConditions.address)
+  const f_AccessCtlConditions = await hre.ethers.getContractFactory(
+    "AccessControlConditions",
+    { signer: deployer }
+  );
+  const c_AccessCtlConditions = await f_AccessCtlConditions.deploy(); /// currently the owner address is hardcoded.  To be replaced by public keys.
+  await c_AccessCtlConditions.deployed();
+  console.log(
+    "Contract for AccessControlConditions deployed to:",
+    c_AccessCtlConditions.address
+  );
 
-  // Deploy LIT Token contract 
-  const f_LITToken = await hre.ethers.getContractFactory('LITToken', {signer : deployer} );
-  const c_LITToken = await  f_LITToken.deploy();  /// currently the owner address is hardcoded.  To be replaced by public keys.
-  await c_LITToken.deployed()
-  console.log('Contract for LITToken deployed to:', c_LITToken.address)
+  // Deploy LIT Token contract
+  const f_LITToken = await hre.ethers.getContractFactory("LITToken", {
+    signer: deployer,
+  });
+  const c_LITToken = await f_LITToken.deploy(); /// currently the owner address is hardcoded.  To be replaced by public keys.
+  await c_LITToken.deployed();
+  console.log("Contract for LITToken deployed to:", c_LITToken.address);
 
   // Deploy staking contract
-  const f_Staking = await hre.ethers.getContractFactory('Staking', {signer : deployer} );
-  const c_Staking = await  f_Staking.deploy(c_LITToken.address);  /// currently the owner address is hardcoded.  To be replaced by public keys.
-  await c_Staking.deployed()
-  console.log('Contract for Staking deployed to:', c_Staking.address)
+  const f_Staking = await hre.ethers.getContractFactory("Staking", {
+    signer: deployer,
+  });
+  const c_Staking = await f_Staking.deploy(c_LITToken.address); /// currently the owner address is hardcoded.  To be replaced by public keys.
+  await c_Staking.deployed();
+  console.log("Contract for Staking deployed to:", c_Staking.address);
 
-  // Deploy Condition Validations Contract 
-  const f_conditionValidation = await hre.ethers.getContractFactory('ConditionValidations', {signer : deployer} );
-  const c_conditionValidation = await  f_conditionValidation.deploy('0x804C96C9750a57FB841f26a7bC9f2815782D8529');  /// currently the owner address is hardcoded.  To be replaced by public keys.
-  await c_conditionValidation.deployed()
-  console.log('Contract for ConditionValidations deployed to:', c_conditionValidation.address)
+  // Deploy Condition Validations Contract
+  const f_conditionValidation = await hre.ethers.getContractFactory(
+    "ConditionValidations",
+    { signer: deployer }
+  );
+  const c_conditionValidation = await f_conditionValidation.deploy(
+    "0x804C96C9750a57FB841f26a7bC9f2815782D8529"
+  ); /// currently the owner address is hardcoded.  To be replaced by public keys.
+  await c_conditionValidation.deployed();
+  console.log(
+    "Contract for ConditionValidations deployed to:",
+    c_conditionValidation.address
+  );
 
   // deploy the PKP contract
   const TokenContractFactory = await ethers.getContractFactory("PKPNFT");
   const TokenContract = await TokenContractFactory.deploy();
   await TokenContract.deployed();
-  console.log('Contract for PKPNFT deployed to:', TokenContract.address)
-  
-  //  Deploy the router contract.
-  const RouterContractFactory = await ethers.getContractFactory("PubkeyRouterAndPermissions");
-  const RouterContract = await RouterContractFactory.deploy(TokenContract.address);
-  await RouterContract.deployed();
-  console.log('Contract for PubkeyRouterAndPermissions deployed to:', RouterContract.address)
+  console.log("Contract for PKPNFT deployed to:", TokenContract.address);
 
+  //  Deploy the router contract.
+  const RouterContractFactory = await ethers.getContractFactory(
+    "PubkeyRouterAndPermissions"
+  );
+  const RouterContract = await RouterContractFactory.deploy(
+    TokenContract.address
+  );
+  await RouterContract.deployed();
+  console.log(
+    "Contract for PubkeyRouterAndPermissions deployed to:",
+    RouterContract.address
+  );
 
   //  Deploy the RateLimitNFT contract.
-  const RateLimitNFTContractFactory = await ethers.getContractFactory("RateLimitNFT");
+  const RateLimitNFTContractFactory = await ethers.getContractFactory(
+    "RateLimitNFT"
+  );
   const RateLimitNFTContract = await RateLimitNFTContractFactory.deploy();
   await RateLimitNFTContract.deployed();
-  console.log('Contract for RateLimitNFT deployed to:', RateLimitNFTContract.address)
-
+  console.log(
+    "Contract for RateLimitNFT deployed to:",
+    RateLimitNFTContract.address
+  );
 
   await TokenContract.setRouterAddress(RouterContract.address);
 
-   // Get contract ASTs into ethernal - note that this is slow.  But at least it's automatic.
-  await hre.ethernal.push({name:'AccessControlConditions', address: c_AccessCtlConditions.address});
-  await hre.ethernal.push({name:'LITToken', address: c_LITToken.address});
-  await hre.ethernal.push({name:'Staking', address: c_Staking.address});
-  await hre.ethernal.push({name:'ConditionValidations', address: c_conditionValidation.address});
-  await hre.ethernal.push({name:'PubkeyRouterAndPermissions', address: RouterContract.address});
-  await hre.ethernal.push({name:'PKPNFT', address: TokenContract.address});
-  await hre.ethernal.push({name:'RateLimitNFT', address: RateLimitNFTContract.address});
+  // Get contract ASTs into ethernal - note that this is slow.  But at least it's automatic.
+  await hre.ethernal.push({
+    name: "AccessControlConditions",
+    address: c_AccessCtlConditions.address,
+  });
+  await hre.ethernal.push({ name: "LITToken", address: c_LITToken.address });
+  await hre.ethernal.push({ name: "Staking", address: c_Staking.address });
+  await hre.ethernal.push({
+    name: "ConditionValidations",
+    address: c_conditionValidation.address,
+  });
+  await hre.ethernal.push({
+    name: "PubkeyRouterAndPermissions",
+    address: RouterContract.address,
+  });
+  await hre.ethernal.push({ name: "PKPNFT", address: TokenContract.address });
+  await hre.ethernal.push({
+    name: "RateLimitNFT",
+    address: RateLimitNFTContract.address,
+  });
 
-
-  // Set this value for the number of nodes to create 
-  // This is primarily useful for setting up test/dev environments. 
-  // The remainder of this script creates wallets for each of the nodes, deploys some ETH (for gas), and then deploys tokens.   
+  // Set this value for the number of nodes to create
+  // This is primarily useful for setting up test/dev environments.
+  // The remainder of this script creates wallets for each of the nodes, deploys some ETH (for gas), and then deploys tokens.
   // With tokens in hand, the nodes can "stake & join" into the primary Staking contract and be run directly,
   // either through a script or via command line arguments.
   // During the deploy process, we also generate a config file for the scripts to use.
@@ -102,139 +144,146 @@ async function main () {
   const nodeTransferAmount = 10000;
   const staking_amount = 100;
 
-  // Mint some LIT Token! 
-  await c_LITToken.mint(await deployer.getAddress() ,initialMintAmount);
+  // Mint some LIT Token!
+  await c_LITToken.mint(await deployer.getAddress(), initialMintAmount);
   const InitialLITbalance = await c_LITToken.balanceOf(deployer.address);
-  console.log("Minted amount of LIT =" , InitialLITbalance.toNumber()   );     // this is a BigInt
+  console.log("Minted amount of LIT =", InitialLITbalance.toNumber()); // this is a BigInt
 
-
-  const wallets = new Array(nodeCount);  
+  const wallets = new Array(nodeCount);
   let current_wallet;
   // Start Initializing nodes
-  // in this case the nodes "own" their wallets - technically the 
+  // in this case the nodes "own" their wallets - technically the
 
-  for (i = 0; i < nodeCount; i++)  {
-    console.log('Processing Node#', i )
+  for (i = 0; i < nodeCount; i++) {
+    console.log("Processing Node#", i);
 
     nodeFileId = i;
-  //  fs.unlinkSync('lit_config' + nodeFileId + '.env');
-
+    //  fs.unlinkSync('lit_config' + nodeFileId + '.env');
 
     // Start building a configuration file!
     console.log("\n\nCreating Node.Config file.... \n\n");
-  // Chain for condition storage and minting/staking contracts
-    
-    f('LIT_CHAIN_NAME = ', hre.network.name ); 
-    f('LIT_CHAIN_ID = 31337 ' );
-    f('LIT_CHAIN_RPC_URL =', hre.network.config.url  );
+    // Chain for condition storage and minting/staking contracts
 
-  // Contract addresses (Condition Validations may also appear in other chains)
-    f('\n');
-    f('LIT_CONTRACT_CONDITIONVALIDATIONS = ', c_conditionValidation.address);
-    f('LIT_CONTRACT_ACCESSCONTROLCONDITIONS = ', c_AccessCtlConditions.address);
-    f('LIT_CONTRACT_LITTOKEN = ', c_LITToken.address);
-    f('LIT_CONTRACT_STAKING = ', c_Staking.address);
-    f('LIT_CONTRACT_PUBKEYROUTERANDPERMISSIONS = ', RouterContract.address);
-    f('LIT_CONTRACT_PKPNFT = ', TokenContract.address);
-    f('LIT_CONTRACT_RATELIMITNFT = ', RateLimitNFTContract.address);
-    f('\n') ;
+    f("LIT_CHAIN_NAME = ", hre.network.name);
+    f("LIT_CHAIN_ID = 31337 ");
+    f("LIT_CHAIN_RPC_URL =", hre.network.config.url);
+
+    // Contract addresses (Condition Validations may also appear in other chains)
+    f("\n");
+    f("LIT_CONTRACT_CONDITIONVALIDATIONS = ", c_conditionValidation.address);
+    f("LIT_CONTRACT_ACCESSCONTROLCONDITIONS = ", c_AccessCtlConditions.address);
+    f("LIT_CONTRACT_LITTOKEN = ", c_LITToken.address);
+    f("LIT_CONTRACT_STAKING = ", c_Staking.address);
+    f("LIT_CONTRACT_PUBKEYROUTERANDPERMISSIONS = ", RouterContract.address);
+    f("LIT_CONTRACT_PKPNFT = ", TokenContract.address);
+    f("LIT_CONTRACT_RATELIMITNFT = ", RateLimitNFTContract.address);
+    f("\n");
 
     const ipAddr = "127.0.0.1";
     const port = 7470 + i;
-    const node_wallet = await hre.ethers.Wallet.createRandom().connect(hre.ethers.provider);
-    
+    const node_wallet = await hre.ethers.Wallet.createRandom().connect(
+      hre.ethers.provider
+    );
+
     // console.log('Impersonation:' ,  ( await hre.network.provider.send('hardhat_impersonateAccount', [node_wallet.address]) ) );
-   // console.log('Signer:' ,  ( await hre.ethers.provider.getSigner(node_wallet.address) ) );
-  console.log('Wallet Address:' ,  ( node_wallet.address ) );
+    // console.log('Signer:' ,  ( await hre.ethers.provider.getSigner(node_wallet.address) ) );
+    console.log("Wallet Address:", node_wallet.address);
 
     wallets[i] = node_wallet;
 
     // using ETH as gas in Hardhat.
-    await deployer.sendTransaction({  
+    await deployer.sendTransaction({
       to: node_wallet.address,
       value: hre.ethers.utils.parseEther("0.001"), // Sends exactly 0.1 coin
     });
 
-    console.log("Node ETH Balance () =" ,  await hre.ethers.provider.getBalance(node_wallet.address)     );     // this is a BigInt
+    console.log(
+      "Node ETH Balance () =",
+      await hre.ethers.provider.getBalance(node_wallet.address)
+    ); // this is a BigInt
 
-    // config file entry   
-    f("LIT_NODE_ADDRESS = " , node_wallet.address.toLowerCase());
-    f("LIT_NODE_PRIVATEKEY = " , node_wallet.privateKey);  
-    f("LIT_NODE_PUBLICKEY = " , node_wallet.publicKey);
-    f("LIT_NODE_DOMAIN_NAME = " , ipAddr)
-    f("LIT_NODE_PORT = " , port)
-    f("ROCKET_PORT = " , port)
+    // config file entry
+    f("LIT_NODE_ADDRESS = ", node_wallet.address.toLowerCase());
+    f("LIT_NODE_PRIVATEKEY = ", node_wallet.privateKey);
+    f("LIT_NODE_PUBLICKEY = ", node_wallet.publicKey);
+    f("LIT_NODE_DOMAIN_NAME = ", ipAddr);
+    f("LIT_NODE_PORT = ", port);
+    f("ROCKET_PORT = ", port);
     f("");
 
-    
-    // the deployer is the minter / holder of LIT tokens 
+    // the deployer is the minter / holder of LIT tokens
     const dLITToken = await c_LITToken.connect(deployer);
     await dLITToken.transfer(node_wallet.address, nodeTransferAmount);
 
-    // approve the transfer to the contract per ERC20   
-    token = await c_LITToken.connect(node_wallet);  
-    console.log("Node Balance () =" ,  (await token.balanceOf(node_wallet.address)).toNumber()   );     // this is a BigInt
+    // approve the transfer to the contract per ERC20
+    token = await c_LITToken.connect(node_wallet);
+    console.log(
+      "Node Balance () =",
+      (await token.balanceOf(node_wallet.address)).toNumber()
+    ); // this is a BigInt
     await token.approve(c_Staking.address, staking_amount);
 
     var node_balance = await c_LITToken.balanceOf(node_wallet.address);
     //console.log("Node Balance (initial) =" , node_balance.toNumber()   );     // this is a BigInt
-    console.log("Staking amount =" , staking_amount   );     // this is a BigInt
+    console.log("Staking amount =", staking_amount); // this is a BigInt
 
     // stake & join for the first epoch.
-    const node_staking = await c_Staking.connect(node_wallet);    
-    
-    await node_staking.stakeAndJoin(
-        staking_amount,
-        ip2int(ipAddr),
-        0,
-        port,
-        node_wallet.address
-      );
+    const node_staking = await c_Staking.connect(node_wallet);
 
-    const post_node_balance = await c_LITToken.balanceOf(node_wallet.address);    
-    console.log("LITbalance (post) =" , post_node_balance.toNumber()   );     // this is a BigInt
+    await node_staking.stakeAndJoin(
+      staking_amount,
+      ip2int(ipAddr),
+      0,
+      port,
+      node_wallet.address
+    );
+
+    const post_node_balance = await c_LITToken.balanceOf(node_wallet.address);
+    console.log("LITbalance (post) =", post_node_balance.toNumber()); // this is a BigInt
 
     await c_Staking.connect(node_wallet);
-    const staking_contract_balance = await c_Staking.balanceOf(node_wallet.address);
-    console.log("Staking balance (post) =" , staking_contract_balance.toNumber()   );     // this is a BigInt
-  
+    const staking_contract_balance = await c_Staking.balanceOf(
+      node_wallet.address
+    );
+    console.log(
+      "Staking balance (post) =",
+      staking_contract_balance.toNumber()
+    ); // this is a BigInt
+
     current_wallet = node_wallet;
-   
   }
 
   console.log("\n\n\nFinished creating log file.  \n");
-  console.log("next up validators set:", await c_Staking.getValidatorsInNextEpoch() );
+  console.log(
+    "next up validators set:",
+    await c_Staking.getValidatorsInNextEpoch()
+  );
 
-
-
-  // if we want to prep our first set of nodes...  >>>  
+  // if we want to prep our first set of nodes...  >>>
   // comment this out, if we want to run these commands from the nodes!
-  
-  // const node_staking = await c_Staking.connect(current_wallet);    
+
+  // const node_staking = await c_Staking.connect(current_wallet);
   // console.log('Locking for first epoch...');
   // await node_staking.lockValidatorsForNextEpoch();
 
   // for (i = 0; i < nodeCount; i++)  {
   //   const wallet = wallets[i];
-  //   const node_staking = await c_Staking.connect(wallet);    
+  //   const node_staking = await c_Staking.connect(wallet);
   //   console.log('Signal Ready for first epoch :', wallet.address );
   //   await node_staking.signalReadyForNextEpoch();
   // }
   // console.log('Advancing to first epoch...');
-  // await node_staking.advanceEpoch();  
+  // await node_staking.advanceEpoch();
   // console.log("Current validators:", await c_Staking.getValidatorsInCurrentEpoch() );
-
-
 }
 
 // We recommend this pattern to be able to use async/await everywhere
 // and properly handle errors.
 main()
   .then(() => process.exit(0))
-  .catch(error => {
-    console.error(error)
-    process.exit(1)
-  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
 
-
-  /// test deployed to : 0x5FbDB2315678afecb367f032d93F642f64180aa3
+/// test deployed to : 0x5FbDB2315678afecb367f032d93F642f64180aa3

--- a/scripts/deploy_all_celo.js
+++ b/scripts/deploy_all_celo.js
@@ -3,20 +3,24 @@
 //
 // When running the script with `hardhat run <script>` you'll find the Hardhat
 // Runtime Environment's members available in the global scope.
-const hre = require('hardhat')
+const hre = require("hardhat");
 const { ip2int, int2ip } = require("../utils.js");
-const fs = require('fs');
-const { ethers, BigNumber } = require('ethers');
-require('dotenv').config();
+const fs = require("fs");
+const { ethers, BigNumber } = require("ethers");
+require("dotenv").config();
 
 // quick & dirty config writing helper!
 let nodeFileId = 1;
-const f = (n , v) =>  {
-  if (v) {  n = n + v };
-  fs.appendFileSync('lit_config' + nodeFileId + '.env', n + '\n', err => { 
-    if (err) { console.error(err)}}
-    );
-}
+const f = (n, v) => {
+  if (v) {
+    n = n + v;
+  }
+  fs.appendFileSync("lit_config" + nodeFileId + ".env", n + "\n", (err) => {
+    if (err) {
+      console.error(err);
+    }
+  });
+};
 
 // because ethers isn't completely compatible....
 const getCeloProvider = () => {
@@ -36,211 +40,240 @@ const getCeloProvider = () => {
   return provider;
 };
 
+async function main() {
+  // we really only need a single deployer & are using HH accounts, or the default account for the connected chain,
+  [deployer, ...signers] = await hre.ethers.getSigners(); /// the deployer is the first account lilsted
 
-async function main () {
-
-  // we really only need a single deployer & are using HH accounts, or the default account for the connected chain,  
-  [deployer, ...signers] = await hre.ethers.getSigners()  /// the deployer is the first account lilsted
-
-//  const chainProvider = hre.ethers.provider;
+  //  const chainProvider = hre.ethers.provider;
   const chainProvider = getCeloProvider();
 
-  // Set these values for the number of nodes to create, and funds to allocate 
+  // Set these values for the number of nodes to create, and funds to allocate
   const decimals = 18;
   const nodeCount = 10;
-  const initialMintAmount =   hre.ethers.utils.parseUnits("1000000",decimals)  ;
-  const nodeTransferAmount =  hre.ethers.utils.parseUnits("10000",decimals)  ;  
-  const staking_amount = hre.ethers.utils.parseUnits("100",decimals)  ;
-
+  const initialMintAmount = hre.ethers.utils.parseUnits("1000000", decimals);
+  const nodeTransferAmount = hre.ethers.utils.parseUnits("10000", decimals);
+  const staking_amount = hre.ethers.utils.parseUnits("100", decimals);
 
   // Deploy Contracts
   console.log("\n\n");
-  console.log("Deploying contracts to : ",  hre.network.name );
-  console.log('Deployer Account:', deployer.address)
+  console.log("Deploying contracts to : ", hre.network.name);
+  console.log("Deployer Account:", deployer.address);
 
-  // Deploy LIT Token contract 
-  const f_LITToken = await hre.ethers.getContractFactory('LITToken', {signer : deployer} );
-  const c_LITToken = await  f_LITToken.deploy();  /// currently the owner address is hardcoded.  To be replaced by public keys.
-  await c_LITToken.deployed()
-  console.log('Contract for LITToken deployed to:', c_LITToken.address)
+  // Deploy LIT Token contract
+  const f_LITToken = await hre.ethers.getContractFactory("LITToken", {
+    signer: deployer,
+  });
+  const c_LITToken = await f_LITToken.deploy(); /// currently the owner address is hardcoded.  To be replaced by public keys.
+  await c_LITToken.deployed();
+  console.log("Contract for LITToken deployed to:", c_LITToken.address);
 
   // Deploy staking contract
-  const f_Staking = await hre.ethers.getContractFactory('Staking', {signer : deployer} );
-  const c_Staking = await  f_Staking.deploy(c_LITToken.address);  /// currently the owner address is hardcoded.  To be replaced by public keys.
-  await c_Staking.deployed()
-  console.log('Contract for Staking deployed to:', c_Staking.address)
+  const f_Staking = await hre.ethers.getContractFactory("Staking", {
+    signer: deployer,
+  });
+  const c_Staking = await f_Staking.deploy(c_LITToken.address); /// currently the owner address is hardcoded.  To be replaced by public keys.
+  await c_Staking.deployed();
+  console.log("Contract for Staking deployed to:", c_Staking.address);
 
   // Deploy Access Control Conditions
-  const f_AccessCtlConditions = await hre.ethers.getContractFactory('AccessControlConditions', {signer : deployer} );
-  const c_AccessCtlConditions = await  f_AccessCtlConditions.deploy();  /// currently the owner address is hardcoded.  To be replaced by public keys.
-  await c_AccessCtlConditions.deployed()
-  console.log('Contract for AccessControlConditions deployed to:', c_AccessCtlConditions.address)
+  const f_AccessCtlConditions = await hre.ethers.getContractFactory(
+    "AccessControlConditions",
+    { signer: deployer }
+  );
+  const c_AccessCtlConditions = await f_AccessCtlConditions.deploy(); /// currently the owner address is hardcoded.  To be replaced by public keys.
+  await c_AccessCtlConditions.deployed();
+  console.log(
+    "Contract for AccessControlConditions deployed to:",
+    c_AccessCtlConditions.address
+  );
 
-  // // Deploy Condition Validations Contract 
-  const f_conditionValidation = await hre.ethers.getContractFactory('ConditionValidations', {signer : deployer} );
-  const c_conditionValidation = await  f_conditionValidation.deploy('0x804C96C9750a57FB841f26a7bC9f2815782D8529');  /// currently the owner address is hardcoded.  To be replaced by public keys.
-  await c_conditionValidation.deployed()
-  console.log('Contract for ConditionValidations deployed to:', c_conditionValidation.address)
+  // // Deploy Condition Validations Contract
+  const f_conditionValidation = await hre.ethers.getContractFactory(
+    "ConditionValidations",
+    { signer: deployer }
+  );
+  const c_conditionValidation = await f_conditionValidation.deploy(
+    "0x804C96C9750a57FB841f26a7bC9f2815782D8529"
+  ); /// currently the owner address is hardcoded.  To be replaced by public keys.
+  await c_conditionValidation.deployed();
+  console.log(
+    "Contract for ConditionValidations deployed to:",
+    c_conditionValidation.address
+  );
 
   // deploy the PKP contract
   const TokenContractFactory = await hre.ethers.getContractFactory("PKPNFT");
   const TokenContract = await TokenContractFactory.deploy();
   await TokenContract.deployed();
-  console.log('Contract for PKPNFT deployed to:', TokenContract.address) 
-  
+  console.log("Contract for PKPNFT deployed to:", TokenContract.address);
+
   //  Deploy the router contract.
-  const RouterContractFactory = await hre.ethers.getContractFactory("PubkeyRouterAndPermissions");
-  const RouterContract = await RouterContractFactory.deploy(TokenContract.address);
+  const RouterContractFactory = await hre.ethers.getContractFactory(
+    "PubkeyRouterAndPermissions"
+  );
+  const RouterContract = await RouterContractFactory.deploy(
+    TokenContract.address
+  );
   await RouterContract.deployed();
-  console.log('Contract for PubkeyRouterAndPermissions deployed to:', RouterContract.address)
+  console.log(
+    "Contract for PubkeyRouterAndPermissions deployed to:",
+    RouterContract.address
+  );
 
   await TokenContract.setRouterAddress(RouterContract.address);
 
   //  Deploy the RateLimitNFT contract.
-  const RateLimitNFTContractFactory = await hre.ethers.getContractFactory("RateLimitNFT");
+  const RateLimitNFTContractFactory = await hre.ethers.getContractFactory(
+    "RateLimitNFT"
+  );
   const RateLimitNFTContract = await RateLimitNFTContractFactory.deploy();
   await RateLimitNFTContract.deployed();
-  console.log('Contract for RateLimitNFT deployed to:', RateLimitNFTContract.address)
+  console.log(
+    "Contract for RateLimitNFT deployed to:",
+    RateLimitNFTContract.address
+  );
 
-
-  // This is primarily useful for setting up test/dev environments. 
-  // The remainder of this script creates wallets for each of the nodes, deploys some ETH (for gas), and then deploys tokens.   
+  // This is primarily useful for setting up test/dev environments.
+  // The remainder of this script creates wallets for each of the nodes, deploys some ETH (for gas), and then deploys tokens.
   // With tokens in hand, the nodes can "stake & join" into the primary Staking contract and be run directly,
   // either through a script or via command line arguments.
   // During the deploy process, we also generate a config file for the scripts to use.
-  
-  // Mint some LIT Token! 
-  await c_LITToken.mint(await deployer.getAddress() ,initialMintAmount);
+
+  // Mint some LIT Token!
+  await c_LITToken.mint(await deployer.getAddress(), initialMintAmount);
   const InitialLITbalance = await c_LITToken.balanceOf(deployer.address);
-  console.log("Minted amount of LIT =" , InitialLITbalance.toNumber()   );     // this is a BigInt
+  console.log("Minted amount of LIT =", InitialLITbalance.toNumber()); // this is a BigInt
 
-
-  const wallets = new Array(nodeCount);  
+  const wallets = new Array(nodeCount);
   let current_wallet;
   // Start Initializing nodes
-  // in this case the nodes "own" their wallets - technically the 
+  // in this case the nodes "own" their wallets - technically the
 
-  for (i = 0; i < nodeCount; i++)  {
-    console.log('Processing Node#', i )
+  for (i = 0; i < nodeCount; i++) {
+    console.log("Processing Node#", i);
 
     nodeFileId = i;
 
-   // Start building a configuration file!
+    // Start building a configuration file!
     console.log("\n\nCreating Node.Config file.... \n\n");
-  // Chain for condition storage and minting/staking contracts
-    
-    f('LIT_CHAIN_NAME = ', hre.network.name ); 
-    f('LIT_CHAIN_ID = ' , hre.network.config.chainId );
-    f('LIT_CHAIN_RPC_URL =', hre.network.config.url  );
+    // Chain for condition storage and minting/staking contracts
 
-  // Contract addresses (Condition Validations may also appear in other chains)
-    f('\n');
-    f('LIT_CONTRACT_LITTOKEN = ', c_LITToken.address);
-    f('LIT_CONTRACT_STAKING = ', c_Staking.address);
-    f('LIT_CONTRACT_CONDITIONVALIDATIONS = ', c_conditionValidation.address);
-    f('LIT_CONTRACT_ACCESSCONTROLCONDITIONS = ', c_AccessCtlConditions.address);
-    f('LIT_CONTRACT_PUBKEYROUTERANDPERMISSIONS = ', RouterContract.address);
-    f('LIT_CONTRACT_PKPNFT = ', TokenContract.address);
-    f('LIT_CONTRACT_RATELIMITNFT = ', RateLimitNFTContract.address);
-    f('\n') ;
+    f("LIT_CHAIN_NAME = ", hre.network.name);
+    f("LIT_CHAIN_ID = ", hre.network.config.chainId);
+    f("LIT_CHAIN_RPC_URL =", hre.network.config.url);
+
+    // Contract addresses (Condition Validations may also appear in other chains)
+    f("\n");
+    f("LIT_CONTRACT_LITTOKEN = ", c_LITToken.address);
+    f("LIT_CONTRACT_STAKING = ", c_Staking.address);
+    f("LIT_CONTRACT_CONDITIONVALIDATIONS = ", c_conditionValidation.address);
+    f("LIT_CONTRACT_ACCESSCONTROLCONDITIONS = ", c_AccessCtlConditions.address);
+    f("LIT_CONTRACT_PUBKEYROUTERANDPERMISSIONS = ", RouterContract.address);
+    f("LIT_CONTRACT_PKPNFT = ", TokenContract.address);
+    f("LIT_CONTRACT_RATELIMITNFT = ", RateLimitNFTContract.address);
+    f("\n");
 
     const ipAddr = "127.0.0.1";
     const port = 7470 + i;
-    const node_wallet = await hre.ethers.Wallet.createRandom().connect(chainProvider);   
-    console.log('Wallet Address:' ,  ( node_wallet.address ) );
+    const node_wallet = await hre.ethers.Wallet.createRandom().connect(
+      chainProvider
+    );
+    console.log("Wallet Address:", node_wallet.address);
 
     wallets[i] = node_wallet;
-    // config file entry   
-    f("LIT_NODE_ADDRESS = " , node_wallet.address.toLowerCase());
-    f("LIT_NODE_PRIVATEKEY = " , node_wallet.privateKey);  
-    f("LIT_NODE_PUBLICKEY = " , node_wallet.publicKey);
-    f("LIT_STAKER_ADDRESS = " , node_wallet.address.toLowerCase());
-    f("LIT_NODE_DOMAIN_NAME = " , ipAddr)
-    f("LIT_NODE_PORT = " , port)
-    f("ROCKET_PORT = " , port)
+    // config file entry
+    f("LIT_NODE_ADDRESS = ", node_wallet.address.toLowerCase());
+    f("LIT_NODE_PRIVATEKEY = ", node_wallet.privateKey);
+    f("LIT_NODE_PUBLICKEY = ", node_wallet.publicKey);
+    f("LIT_STAKER_ADDRESS = ", node_wallet.address.toLowerCase());
+    f("LIT_NODE_DOMAIN_NAME = ", ipAddr);
+    f("LIT_NODE_PORT = ", port);
+    f("ROCKET_PORT = ", port);
     f("");
 
-
     // from the deployer, seed the new wallet with some  native coin to cover gas.
-    var nativeTransactionReceipt = await deployer.sendTransaction({  
+    var nativeTransactionReceipt = await deployer.sendTransaction({
       to: node_wallet.address,
       value: hre.ethers.utils.parseEther("0.1"), // Sends exactly 0.1 CELO coin
     });
 
     await nativeTransactionReceipt.wait(0);
-    console.log("Node Balance (native) =" ,  await (await chainProvider.getBalance(node_wallet.address))   );     // this is a BigInt
-    
-    // the deployer is the minter / holder of LIT tokens 
+    console.log(
+      "Node Balance (native) =",
+      await await chainProvider.getBalance(node_wallet.address)
+    ); // this is a BigInt
+
+    // the deployer is the minter / holder of LIT tokens
     const dLITToken = await c_LITToken.connect(deployer);
-    await dLITToken.approve(node_wallet.address,  nodeTransferAmount  );
+    await dLITToken.approve(node_wallet.address, nodeTransferAmount);
     await dLITToken.transfer(node_wallet.address, nodeTransferAmount);
 
-    // approve the transfer to the contract per ERC20   
-    token = await c_LITToken.connect(node_wallet);  
-    console.log("Node Balance (LIT-Approve) =" ,  (await token.balanceOf(node_wallet.address))   );     // this is a BigInt
-    await token.approve(c_Staking.address,  staking_amount  );
+    // approve the transfer to the contract per ERC20
+    token = await c_LITToken.connect(node_wallet);
+    console.log(
+      "Node Balance (LIT-Approve) =",
+      await token.balanceOf(node_wallet.address)
+    ); // this is a BigInt
+    await token.approve(c_Staking.address, staking_amount);
 
     var node_balance = await c_LITToken.balanceOf(node_wallet.address);
-    console.log("Node Balance (LIT-initial) =" , node_balance   );     // this is a BigInt
-    console.log("Staking amount =" , staking_amount   );     // this is a BigInt
+    console.log("Node Balance (LIT-initial) =", node_balance); // this is a BigInt
+    console.log("Staking amount =", staking_amount); // this is a BigInt
 
     // stake & join for the first epoch.
-    const node_staking = await c_Staking.connect(node_wallet);    
-    
-    await node_staking.stakeAndJoin(
-        staking_amount,
-        ip2int(ipAddr),
-        0,
-        port,
-        node_wallet.address
-      );
+    const node_staking = await c_Staking.connect(node_wallet);
 
-    
-    const post_node_balance = await c_LITToken.balanceOf(node_wallet.address);    
-    console.log("LITbalance (post) =" , post_node_balance   );     // this is a BigInt
+    await node_staking.stakeAndJoin(
+      staking_amount,
+      ip2int(ipAddr),
+      0,
+      port,
+      node_wallet.address
+    );
+
+    const post_node_balance = await c_LITToken.balanceOf(node_wallet.address);
+    console.log("LITbalance (post) =", post_node_balance); // this is a BigInt
 
     await c_Staking.connect(node_wallet);
-    const staking_contract_balance = await c_Staking.balanceOf(node_wallet.address);
-    console.log("Staking balance (post) =" , staking_contract_balance   );     // this is a BigInt
-  
+    const staking_contract_balance = await c_Staking.balanceOf(
+      node_wallet.address
+    );
+    console.log("Staking balance (post) =", staking_contract_balance); // this is a BigInt
+
     current_wallet = node_wallet;
-   
   }
 
   console.log("\n\n\nFinished creating log file.  \n");
-  console.log("next up validators set:", await c_Staking.getValidatorsInNextEpoch() );
+  console.log(
+    "next up validators set:",
+    await c_Staking.getValidatorsInNextEpoch()
+  );
 
-
-
-  // if we want to prep our first set of nodes...  >>>  
+  // if we want to prep our first set of nodes...  >>>
   // comment this out, if we want to run these commands from the nodes!
-  
-  // const node_staking = await c_Staking.connect(current_wallet);    
+
+  // const node_staking = await c_Staking.connect(current_wallet);
   // console.log('Locking for first epoch...');
   // await node_staking.lockValidatorsForNextEpoch();
 
   // for (i = 0; i < nodeCount; i++)  {
   //   const wallet = wallets[i];
-  //   const node_staking = await c_Staking.connect(wallet);    
+  //   const node_staking = await c_Staking.connect(wallet);
   //   console.log('Signal Ready for first epoch :', wallet.address );
   //   await node_staking.signalReadyForNextEpoch();
   // }
   // console.log('Advancing to first epoch...');
-  // await node_staking.advanceEpoch();  
+  // await node_staking.advanceEpoch();
   // console.log("Current validators:", await c_Staking.getValidatorsInCurrentEpoch() );
-
-
-
 }
 
 // We recommend this pattern to be able to use async/await everywhere
 // and properly handle errors.
 main()
   .then(() => process.exit(0))
-  .catch(error => {
-    console.error(error)
-    process.exit(1)
-  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
 
-
-  /// test deployed to : 7.355248197 CELO ($5.617 USD) //  6.3439029795 CELO ($4.860 USD)
+/// test deployed to : 7.355248197 CELO ($5.617 USD) //  6.3439029795 CELO ($4.860 USD)

--- a/scripts/sample-script.js
+++ b/scripts/sample-script.js
@@ -3,9 +3,9 @@
 //
 // When running the script with `hardhat run <script>` you'll find the Hardhat
 // Runtime Environment's members available in the global scope.
-const hre = require('hardhat')
+const hre = require("hardhat");
 
-async function main () {
+async function main() {
   // Hardhat always runs the compile task when running scripts with its command
   // line interface.
   //
@@ -14,19 +14,19 @@ async function main () {
   // await hre.run('compile');
 
   // We get the contract to deploy
-  const Greeter = await hre.ethers.getContractFactory('Greeter')
-  const greeter = await Greeter.deploy('Hello, Hardhat!')
+  const Greeter = await hre.ethers.getContractFactory("Greeter");
+  const greeter = await Greeter.deploy("Hello, Hardhat!");
 
-  await greeter.deployed()
+  await greeter.deployed();
 
-  console.log('Greeter deployed to:', greeter.address)
+  console.log("Greeter deployed to:", greeter.address);
 }
 
 // We recommend this pattern to be able to use async/await everywhere
 // and properly handle errors.
 main()
   .then(() => process.exit(0))
-  .catch(error => {
-    console.error(error)
-    process.exit(1)
-  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/test/AccessControlConditions.js
+++ b/test/AccessControlConditions.js
@@ -32,7 +32,7 @@ describe("AccessControlConditions", function () {
       let tester;
       const key = 0x1234;
       const value = 0x5678;
-      const securityHash = 0x9ABC;
+      const securityHash = 0x9abc;
       const chainId = 1;
       const permanent = false;
 
@@ -40,7 +40,13 @@ describe("AccessControlConditions", function () {
 
       beforeEach(
         async () =>
-          await contract.storeCondition(key, value, securityHash, chainId, permanent)
+          await contract.storeCondition(
+            key,
+            value,
+            securityHash,
+            chainId,
+            permanent
+          )
       );
 
       beforeEach(async () => (contract = contract.connect(tester)));
@@ -68,7 +74,7 @@ describe("AccessControlConditions", function () {
       let tester;
       const key = 0x1234;
       const value = 0x5678;
-      const securityHash = 0x9ABC;
+      const securityHash = 0x9abc;
       const chainId = 1;
       const permanent = false;
 
@@ -79,7 +85,13 @@ describe("AccessControlConditions", function () {
 
       beforeEach(
         async () =>
-          await contract.storeCondition(key, value, securityHash, chainId, permanent)
+          await contract.storeCondition(
+            key,
+            value,
+            securityHash,
+            chainId,
+            permanent
+          )
       );
 
       beforeEach(async () => (contract = contract.connect(tester)));
@@ -104,12 +116,24 @@ describe("AccessControlConditions", function () {
 
         // attempt to update it with the wrong address.  it should revert.
         expect(
-          contract.storeCondition(key, newValue, newSecurityHash, newChainId, permanent)
+          contract.storeCondition(
+            key,
+            newValue,
+            newSecurityHash,
+            newChainId,
+            permanent
+          )
         ).revertedWith("Only the condition creator can update it");
 
         // update with the correct address
         contract = contract.connect(creator);
-        await contract.storeCondition(key, newValue, newSecurityHash, newChainId, permanent);
+        await contract.storeCondition(
+          key,
+          newValue,
+          newSecurityHash,
+          newChainId,
+          permanent
+        );
 
         [
           valueFromContract,
@@ -131,7 +155,7 @@ describe("AccessControlConditions", function () {
       let tester;
       const key = 0x1234;
       const value = 0x5678;
-      const securityHash = 0x9ABC;
+      const securityHash = 0x9abc;
       const chainId = 1;
       const permanent = true;
 
@@ -142,7 +166,13 @@ describe("AccessControlConditions", function () {
 
       beforeEach(
         async () =>
-          await contract.storeCondition(key, value, securityHash, chainId, permanent)
+          await contract.storeCondition(
+            key,
+            value,
+            securityHash,
+            chainId,
+            permanent
+          )
       );
 
       beforeEach(async () => (contract = contract.connect(tester)));
@@ -166,7 +196,13 @@ describe("AccessControlConditions", function () {
         const newChainId = 2;
         contract = contract.connect(creator);
         expect(
-          contract.storeCondition(key, newValue, newSecurityHash, newChainId, permanent)
+          contract.storeCondition(
+            key,
+            newValue,
+            newSecurityHash,
+            newChainId,
+            permanent
+          )
         ).revertedWith(
           "This condition was stored with the Permanent flag and cannot be updated"
         );
@@ -188,14 +224,14 @@ describe("AccessControlConditions", function () {
     });
   });
 
-  describe("Store condition with signer and retrieve", function() {
+  describe("Store condition with signer and retrieve", function () {
     context("when key is incorrect", async () => {
       let trustedSigner;
       let creator;
       let tester;
       const key = 0x1234;
       const value = 0x5678;
-      const securityHash = 0x9ABC;
+      const securityHash = 0x9abc;
       const chainId = 1;
       const permanent = false;
 
@@ -206,14 +242,16 @@ describe("AccessControlConditions", function () {
         await contract.setSigner(trustedSigner.address);
 
         // trusted signer sets condition
-        await contract.connect(trustedSigner).storeConditionWithSigner(
-          key,
-          value,
-          securityHash,
-          chainId,
-          permanent,
-          creator.address
-        );
+        await contract
+          .connect(trustedSigner)
+          .storeConditionWithSigner(
+            key,
+            value,
+            securityHash,
+            chainId,
+            permanent,
+            creator.address
+          );
       });
 
       it("retrieves empty condition", async () => {
@@ -239,23 +277,25 @@ describe("AccessControlConditions", function () {
         const [trustedSigner, notSigner, ...remainingSigners] = signers;
         const key = 0x1234;
         const value = 0x5678;
-        const securityHash = 0x9ABC;
+        const securityHash = 0x9abc;
         const chainId = 1;
         const permanent = false;
 
         // set signer
-        await contract.setSigner(notSigner.address)
+        await contract.setSigner(notSigner.address);
 
         expect(
-          contract.connect(trustedSigner).storeConditionWithSigner(
-            key,
-            value,
-            securityHash,
-            chainId,
-            permanent,
-            notSigner.address
-          )
-        ).revertedWith("Only signer can call storeConditionsWithSigner.")
+          contract
+            .connect(trustedSigner)
+            .storeConditionWithSigner(
+              key,
+              value,
+              securityHash,
+              chainId,
+              permanent,
+              notSigner.address
+            )
+        ).revertedWith("Only signer can call storeConditionsWithSigner.");
       });
     });
 
@@ -265,7 +305,7 @@ describe("AccessControlConditions", function () {
       let tester;
       const key = 0x1234;
       const value = 0x5678;
-      const securityHash = 0x9ABC;
+      const securityHash = 0x9abc;
       const chainId = 1;
       const permanent = false;
 
@@ -276,16 +316,18 @@ describe("AccessControlConditions", function () {
         await contract.setSigner(trustedSigner.address);
 
         // trusted signer sets condition
-        await contract.connect(trustedSigner).storeConditionWithSigner(
-          key,
-          value,
-          securityHash,
-          chainId,
-          permanent,
-          creator.address
-        );
+        await contract
+          .connect(trustedSigner)
+          .storeConditionWithSigner(
+            key,
+            value,
+            securityHash,
+            chainId,
+            permanent,
+            creator.address
+          );
       });
-      
+
       it("retrieves condition and fails to update it with incorrect creator", async () => {
         let [
           valueFromContract,
@@ -306,14 +348,16 @@ describe("AccessControlConditions", function () {
 
         // attempt to update it with the wrong address.  it should revert.
         expect(
-          contract.connect(trustedSigner).storeConditionWithSigner(
-            key,
-            newValue,
-            newSecurityHash,
-            newChainId,
-            permanent,
-            tester.address,
-          )
+          contract
+            .connect(trustedSigner)
+            .storeConditionWithSigner(
+              key,
+              newValue,
+              newSecurityHash,
+              newChainId,
+              permanent,
+              tester.address
+            )
         ).revertedWith("Only the condition creator can update it");
 
         // verify that nothing changed
@@ -330,7 +374,7 @@ describe("AccessControlConditions", function () {
         expect(permanentFromContract).equal(permanent);
         expect(creatorFromContract).equal(creator.address);
       });
-      
+
       it("retrieves condition and fails to update it with correct creator", async () => {
         let [
           valueFromContract,
@@ -351,14 +395,16 @@ describe("AccessControlConditions", function () {
 
         // attempt to update it with the wrong address.  it should revert.
         expect(
-          contract.connect(trustedSigner).storeConditionWithSigner(
-            key,
-            newValue,
-            newSecurityHash,
-            newChainId,
-            permanent,
-            creator.address,
-          )
+          contract
+            .connect(trustedSigner)
+            .storeConditionWithSigner(
+              key,
+              newValue,
+              newSecurityHash,
+              newChainId,
+              permanent,
+              creator.address
+            )
         ).revertedWith("Signer cannot update conditions");
 
         // verify that nothing changed
@@ -374,7 +420,7 @@ describe("AccessControlConditions", function () {
         expect(chainIdFromContract).equal(chainId);
         expect(permanentFromContract).equal(permanent);
         expect(creatorFromContract).equal(creator.address);
-      })
+      });
     });
 
     context("when key is correct and condition is permanent", async () => {
@@ -383,7 +429,7 @@ describe("AccessControlConditions", function () {
       let tester;
       const key = 0x1234;
       const value = 0x5678;
-      const securityHash = 0x9ABC;
+      const securityHash = 0x9abc;
       const chainId = 1;
       const permanent = true;
 
@@ -394,14 +440,16 @@ describe("AccessControlConditions", function () {
         await contract.setSigner(trustedSigner.address);
 
         // trusted signer sets condition
-        await contract.connect(trustedSigner).storeConditionWithSigner(
-          key,
-          value,
-          securityHash,
-          chainId,
-          permanent,
-          creator.address
-        );
+        await contract
+          .connect(trustedSigner)
+          .storeConditionWithSigner(
+            key,
+            value,
+            securityHash,
+            chainId,
+            permanent,
+            creator.address
+          );
       });
 
       it("retrieves condition and fails to update it", async () => {
@@ -422,14 +470,16 @@ describe("AccessControlConditions", function () {
         const newValue = 0x8765;
         const newChainId = 2;
         expect(
-          contract.connect(trustedSigner).storeConditionWithSigner(
-            key,
-            newValue,
-            newSecurityHash,
-            newChainId,
-            permanent,
-            creator.address,
-          )
+          contract
+            .connect(trustedSigner)
+            .storeConditionWithSigner(
+              key,
+              newValue,
+              newSecurityHash,
+              newChainId,
+              permanent,
+              creator.address
+            )
         ).revertedWith(
           "This condition was stored with the Permanent flag and cannot be updated"
         );
@@ -448,6 +498,6 @@ describe("AccessControlConditions", function () {
         expect(permanentFromContract).equal(permanent);
         expect(creatorFromContract).equal(creator.address);
       });
-    })
+    });
   });
 });

--- a/test/LITToken.js
+++ b/test/LITToken.js
@@ -1,62 +1,80 @@
-const { expect } = require('chai')
+const { expect } = require("chai");
 
-describe('LITToken', function () {
-  let deployer
-  let signers
-  let token
+describe("LITToken", function () {
+  let deployer;
+  let signers;
+  let token;
 
-  let TokenFactory
+  let TokenFactory;
 
   before(async () => {
-    TokenFactory = await ethers.getContractFactory('LITToken')
-  })
+    TokenFactory = await ethers.getContractFactory("LITToken");
+  });
 
   beforeEach(async () => {
-    [deployer, ...signers] = await ethers.getSigners()
-  })
+    [deployer, ...signers] = await ethers.getSigners();
+  });
 
   beforeEach(async () => {
-    token = await TokenFactory.deploy()
-  })
+    token = await TokenFactory.deploy();
+  });
 
-  it('grants the admin role to the deployer', async () => {
-    expect(await token.hasRole(await token.ADMIN_ROLE(), await deployer.getAddress())).is.true
-  })
+  it("grants the admin role to the deployer", async () => {
+    expect(
+      await token.hasRole(await token.ADMIN_ROLE(), await deployer.getAddress())
+    ).is.true;
+  });
 
-  it('grants the minter role to the deployer', async () => {
-    expect(await token.hasRole(await token.MINTER_ROLE(), await deployer.getAddress())).is.true
-  })
+  it("grants the minter role to the deployer", async () => {
+    expect(
+      await token.hasRole(
+        await token.MINTER_ROLE(),
+        await deployer.getAddress()
+      )
+    ).is.true;
+  });
 
-  describe('mint', async () => {
-    context('when unauthorized', async () => {
-      let unauthorizedMinter
-      let recipient
+  describe("mint", async () => {
+    context("when unauthorized", async () => {
+      let unauthorizedMinter;
+      let recipient;
 
-      beforeEach(async () => [unauthorizedMinter, recipient, ...signers] = signers)
+      beforeEach(
+        async () => ([unauthorizedMinter, recipient, ...signers] = signers)
+      );
 
-      beforeEach(async () => token = token.connect(unauthorizedMinter))
+      beforeEach(async () => (token = token.connect(unauthorizedMinter)));
 
-      it('reverts', async () => {
-        expect(token.mint(await recipient.getAddress(), 1))
-          .revertedWith('LITToken: only minter')
-      })
-    })
+      it("reverts", async () => {
+        expect(token.mint(await recipient.getAddress(), 1)).revertedWith(
+          "LITToken: only minter"
+        );
+      });
+    });
 
-    context('when authorized', async () => {
-      let minter
-      let recipient
-      const amount = 1000
+    context("when authorized", async () => {
+      let minter;
+      let recipient;
+      const amount = 1000;
 
-      beforeEach(async () => [minter, recipient, ...signers] = signers)
+      beforeEach(async () => ([minter, recipient, ...signers] = signers));
 
-      beforeEach(async () => await token.grantRole(await token.MINTER_ROLE(), await minter.getAddress()))
+      beforeEach(
+        async () =>
+          await token.grantRole(
+            await token.MINTER_ROLE(),
+            await minter.getAddress()
+          )
+      );
 
-      beforeEach(async () => token = token.connect(minter))
+      beforeEach(async () => (token = token.connect(minter)));
 
-      it('mints tokens', async () => {
-        await token.mint(await recipient.getAddress(), amount)
-        expect(await token.balanceOf(await recipient.getAddress())).equal(amount)
-      })
-    })
-  })
-})
+      it("mints tokens", async () => {
+        await token.mint(await recipient.getAddress(), amount);
+        expect(await token.balanceOf(await recipient.getAddress())).equal(
+          amount
+        );
+      });
+    });
+  });
+});

--- a/test/PKPPermissions.js
+++ b/test/PKPPermissions.js
@@ -541,7 +541,7 @@ describe("PKPPermissions", function () {
           group,
           multiProof.proof,
           multiProof.proofFlags,
-          multiProof.leaves.map(l => tree.leafHash(l))
+          multiProof.leaves.map((l) => tree.leafHash(l))
         );
         expect(verified).equal(true);
 
@@ -563,7 +563,6 @@ describe("PKPPermissions", function () {
         );
         expect(verified).equal(false);
       });
-
     });
   });
 


### PR DESCRIPTION
Now we can use `npm run prettier` or `yarn prettier` to format the code consistently

Signed-off-by: Raymond Feng <enjoyjava@gmail.com>